### PR TITLE
pump: add clean pump .node file task in start.yml

### DIFF
--- a/start.yml
+++ b/start.yml
@@ -79,6 +79,10 @@
   tags:
     - tidb
   tasks:
+    - name: clean pump .node file
+      file: path={{ pump_data_dir }}/.node state=absent
+      when: enable_binlog
+
     - name: start pump
       shell: cd {{ deploy_dir }}/scripts && ./start_{{ item }}.sh
       with_items:


### PR DESCRIPTION
pump:
- add clean pump .node file task in start.yml,  in case of deploying two pump on one host, when deploying multiple times and misconfiguration, we need to delete .node file manually, or drainer can't obtain right pump infomation.