### PR TITLE
roles/tikv: add TZ setting before start tikv

### DIFF
--- a/roles/tikv/templates/run_tikv.sh.j2
+++ b/roles/tikv/templates/run_tikv.sh.j2
@@ -21,6 +21,8 @@ cd "{{ deploy_dir }}" || exit 1
 
 export RUST_BACKTRACE=1
 
+export TZ=${TZ:-/etc/localtime}
+
 echo -n 'sync ... '
 stat=$(time sync)
 echo ok


### PR DESCRIPTION
If TZ is not set, tikv will stat(/etc/localtime) twice every logging operation.