### PR TITLE
bootstrap: benchmark the write speed of tikv disk

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -26,5 +26,12 @@
   roles:
     - pre-ansible
     - bootstrap
+
+- name: benchmark the write speed of tikv deploy_dir disk
+  hosts: tikv_servers
+  gather_facts: false
+  roles:
+    - { role: machine_benchmark, when: machine_benchmark }
+
 # FIXME: will fail when using pipeline connection
 #    - check_config_dynamic

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -27,7 +27,7 @@
     - pre-ansible
     - bootstrap
 
-- name: benchmark the write speed of tikv deploy_dir disk
+- name: machine benchmark
   hosts: tikv_servers
   gather_facts: false
   roles:

--- a/inventory.ini
+++ b/inventory.ini
@@ -51,6 +51,7 @@ cluster_name = test-cluster
 enable_elk = False
 enable_firewalld = False
 enable_ntpd = False
+machine_benchmark = True
 
 # binlog trigger
 enable_binlog = False

--- a/roles/machine_benchmark/defaults/main.yml
+++ b/roles/machine_benchmark/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+# dd write speed (MB/s)
+min_write_speed: 15
+

--- a/roles/machine_benchmark/tasks/main.yml
+++ b/roles/machine_benchmark/tasks/main.yml
@@ -3,6 +3,9 @@
 - name: Benchmark the write speed of tikv deploy_dir disk with dd command 
   shell: "dd bs=4k count=250000 oflag=direct if=/dev/zero of={{ deploy_dir }}/io_test.txt 2>&1 | awk '/MB/{print $(NF-1)}'"
   register: disk_write_speed
+  
+- debug:
+    msg: "run command on tikv servers: `dd bs=4k count=250000 oflag=direct if=/dev/zero of={{ deploy_dir }}/io_test.txt 2>&1 | awk '/MB/{print $(NF-1)}'`, and the result is {{ disk_write_speed.stdout }} MB/s."
 
 - name: Preflight check - Does the write speed of tikv deploy_dir disk meet requirement
   fail:

--- a/roles/machine_benchmark/tasks/main.yml
+++ b/roles/machine_benchmark/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Benchmark the write speed of tikv deploy_dir disk with dd command 
+  shell: "dd bs=4k count=250000 oflag=direct if=/dev/zero of={{ deploy_dir }}/io_test.txt 2>&1 | awk '/MB/{print $(NF-1)}'"
+  register: disk_write_speed
+
+- name: Preflight check - Does the write speed of tikv deploy_dir disk meet requirement
+  fail:
+    msg: 'the write speed of tikv deploy_dir disk is too slow: {{ disk_write_speed.stdout }} MB/s < {{ min_write_speed }} MB/s'
+  when: disk_write_speed.stdout|int < min_write_speed|int
+
+- name: Clean disk benchmark temporary file
+  file: path={{ deploy_dir }}/io_test.txt state=absent


### PR DESCRIPTION
- Benchmark the write speed of tikv deploy_dir disk with dd command(`dd bs=4k count=250000 oflag=direct if=/dev/zero of={{ deploy_dir }}/io_test.txt`,  add the oflag parameter to bypass the disk page cache)
- fail if speed less than min_write_speed
- add `machine_benchmark = True`  in the inventory.ini