### PR TITLE
fix no attribute 'node_exporter_port'

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -23,6 +23,10 @@ fetch_log_dir: "{{ playbook_dir }}/fetch_logfile"
 # Used by monitoring modules
 cluster_name: test-cluster
 
+# default configuration for multiple host groups and roles
+node_exporter_port: 9100
+
+
 
 
 

--- a/group_vars/monitored_servers.yml
+++ b/group_vars/monitored_servers.yml
@@ -1,3 +1,3 @@
 ---
 
-node_exporter_port: 9100
+

--- a/group_vars/monitoring_servers.yml
+++ b/group_vars/monitoring_servers.yml
@@ -2,4 +2,5 @@
 
 prometheus_port: 9090
 pushgateway_port: 9091
+node_exporter_port: 9100
 

--- a/group_vars/monitoring_servers.yml
+++ b/group_vars/monitoring_servers.yml
@@ -2,5 +2,4 @@
 
 prometheus_port: 9090
 pushgateway_port: 9091
-node_exporter_port: 9100
 

--- a/roles/node_exporter/defaults/main.yml
+++ b/roles/node_exporter/defaults/main.yml
@@ -2,8 +2,6 @@
 
 # default configuration for node_exporter
 
-node_exporter_port: 9100
-
 node_exporter_log_level: info
 node_exporter_log_dir: "{{ deploy_dir }}/log"
 node_exporter_log_filename: "node_exporter.log"

--- a/roles/pd/tasks/main.yml
+++ b/roles/pd/tasks/main.yml
@@ -9,7 +9,7 @@
   - "{{ pd_data_dir }}"
   - "{{ deploy_dir }}/status/{{ role_name }}"
 
-- name: deply binary
+- name: deploy binary
   copy: src="{{ resources_dir }}/bin/pd-server" dest="{{ deploy_dir }}/bin/" mode=0755 backup=yes
   register: pd_binary
 


### PR DESCRIPTION
- Fix: prometheus.yml.j2 task can't obtain node_exporter_port  attribute when deploying prometheus on separate server.
- Fix typo.