### PR TITLE
bootstrap: add dd command LANG

### DIFF
--- a/roles/machine_benchmark/tasks/main.yml
+++ b/roles/machine_benchmark/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
 - name: Benchmark the write speed of tikv deploy_dir disk with dd command 
-  shell: "dd bs=4k count=250000 oflag=direct if=/dev/zero of={{ deploy_dir }}/io_test.txt 2>&1 | awk '/MB/{print $(NF-1)}'"
+  shell: "LANG='en_US.UTF-8' dd bs=4k count=250000 oflag=direct if=/dev/zero of={{ deploy_dir }}/io_test.txt 2>&1 | awk '/MB/{print $(NF-1)}'"
   register: disk_write_speed
   
 - debug:
-    msg: "run command on tikv servers: `dd bs=4k count=250000 oflag=direct if=/dev/zero of={{ deploy_dir }}/io_test.txt 2>&1 | awk '/MB/{print $(NF-1)}'`, and the result is {{ disk_write_speed.stdout }} MB/s."
+    msg: "run command on tikv servers: `LANG='en_US.UTF-8' dd bs=4k count=250000 oflag=direct if=/dev/zero of={{ deploy_dir }}/io_test.txt 2>&1 | awk '/MB/{print $(NF-1)}'`, and the result is {{ disk_write_speed.stdout }} MB/s."
 
 - name: Preflight check - Does the write speed of tikv deploy_dir disk meet requirement
   fail:


### PR DESCRIPTION
When using awk to filter the result of dd command, FS is different between LANG='en_US.UTF-8' and LANG='zh_CN.UTF-8'. Set LANG env for it.