### PR TITLE
Use systemd to track daemons instead supervisord

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ resources/
 fact_files/
 .vagrant/
 *.pyc
+scripts/dests.json
+hosts.ini

--- a/inventory.ini
+++ b/inventory.ini
@@ -57,6 +57,7 @@ enable_ntpd = False
 machine_benchmark = True
 set_hostname = False
 tidb_version = latest
+use_systemd = False
 
 # binlog trigger
 enable_binlog = False

--- a/roles/grafana/tasks/tasks.yml
+++ b/roles/grafana/tasks/tasks.yml
@@ -48,6 +48,23 @@
   vars:
     role_status_dir: status/{{ role_name }}
 
+- name: create systemd service configuration
+  template:
+    src: "grafana.service.j2"
+    dest: "/etc/systemd/system/grafana.service"
+    mode: 0644
+  when: use_systemd
+  vars:
+    - ansible_become: false
+    - ansible_become_user: root
+
+- name: reload systemd
+  shell: "systemctl daemon-reload"
+  when: use_systemd
+  vars:
+    - ansible_become: false
+    - ansible_become_user: root
+
 - name: prepare firewalld white list
   set_fact:
     firewalld_ports: "{{ [grafana_port ~ '/tcp'] + firewalld_ports }}"

--- a/roles/grafana/templates/grafana.service.j2
+++ b/roles/grafana/templates/grafana.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Grafana Service
+After=syslog.target network.target remote-fs.target nss-lookup.target
+
+[Service]
+LimitNOFILE=1000000
+ExecStart={{ deploy_dir }}/scripts/run_grafana.sh
+Restart=on-failure
+User={{ deploy_user }}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/grafana/templates/run_grafana.sh.j2
+++ b/roles/grafana/templates/run_grafana.sh.j2
@@ -7,6 +7,9 @@ ulimit -n 1000000
 # exec > >(tee -i -a "{{ grafana_log_dir }}/{{ grafana_log_filename }}")
 # exec 2>&1
 
+DEPLOY_DIR={{ deploy_dir }}
+cd "${DEPLOY_DIR}" || exit 1
+
 exec opt/grafana/bin/grafana-server \
     --homepath="{{ deploy_dir }}/opt/grafana" \
     --config="{{ deploy_dir }}/opt/grafana/conf/grafana.ini"

--- a/roles/node_exporter/tasks/main.yml
+++ b/roles/node_exporter/tasks/main.yml
@@ -26,6 +26,23 @@
   vars:
     role_status_dir: status/{{ role_name }}
 
+- name: create systemd service configuration
+  template:
+    src: "node-exporter.service.j2"
+    dest: "/etc/systemd/system/node-exporter.service"
+    mode: 0644
+  when: use_systemd
+  vars:
+    - ansible_become: false
+    - ansible_become_user: root
+
+- name: reload systemd
+  shell: "systemctl daemon-reload"
+  when: use_systemd
+  vars:
+    - ansible_become: false
+    - ansible_become_user: root
+
 - name: prepare firewalld white list
   set_fact:
     firewalld_ports: "{{ [node_exporter_port ~ '/tcp'] + firewalld_ports }}"

--- a/roles/node_exporter/templates/node-exporter.service.j2
+++ b/roles/node_exporter/templates/node-exporter.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Node Expoter
+After=syslog.target network.target remote-fs.target nss-lookup.target
+
+[Service]
+LimitNOFILE=1000000
+ExecStart={{ deploy_dir }}/scripts/run_node_exporter.sh
+Restart=on-failure
+User={{ deploy_user }}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/node_exporter/templates/run_node_exporter.sh.j2
+++ b/roles/node_exporter/templates/run_node_exporter.sh.j2
@@ -4,6 +4,9 @@ ulimit -n 1000000
 
 # WARNING: This file was auto-generated. Do not edit!
 #          All your edit might be overwritten!
+DEPLOY_DIR={{ deploy_dir }}
+cd "${DEPLOY_DIR}" || exit 1
+
 exec > >(tee -i -a "{{ node_exporter_log_dir }}/{{ node_exporter_log_filename }}")
 exec 2>&1
 

--- a/roles/pd/tasks/main.yml
+++ b/roles/pd/tasks/main.yml
@@ -66,6 +66,23 @@
   vars:
     role_status_dir: status/{{ role_name }}
 
+- name: create systemd service configuration
+  template:
+    src: "pd.service.j2"
+    dest: "/etc/systemd/system/pd.service"
+    mode: 0644
+  when: use_systemd
+  vars:
+    - ansible_become: false
+    - ansible_become_user: root
+
+- name: reload systemd
+  shell: "systemctl daemon-reload"
+  when: use_systemd
+  vars:
+    - ansible_become: false
+    - ansible_become_user: root
+
 - name: prepare firewalld white list
   set_fact:
     firewalld_ports: "{{ [pd_peer_port ~ '/tcp', pd_client_port ~ '/tcp'] + firewalld_ports }}"

--- a/roles/pd/templates/pd.service.j2
+++ b/roles/pd/templates/pd.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=PD Service
+After=syslog.target network.target remote-fs.target nss-lookup.target
+
+[Service]
+LimitNOFILE=1000000
+ExecStart={{ deploy_dir }}/scripts/run_pd.sh
+Restart=on-failure
+User={{ deploy_user }}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -54,6 +54,23 @@
   vars:
     role_status_dir: status/{{ role_name }}
 
+- name: create systemd service configuration
+  template:
+    src: "prometheus.service.j2"
+    dest: "/etc/systemd/system/prometheus.service"
+    mode: 0644
+  when: use_systemd
+  vars:
+    - ansible_become: false
+    - ansible_become_user: root
+
+- name: reload systemd
+  shell: "systemctl daemon-reload"
+  when: use_systemd
+  vars:
+    - ansible_become: false
+    - ansible_become_user: root
+
 - name: prepare firewalld white list
   set_fact:
     firewalld_ports: "{{ [prometheus_port ~ '/tcp'] + firewalld_ports }}"

--- a/roles/prometheus/templates/prometheus.service.j2
+++ b/roles/prometheus/templates/prometheus.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Prometheus Service
+After=syslog.target network.target remote-fs.target nss-lookup.target
+
+[Service]
+LimitNOFILE=1000000
+ExecStart={{ deploy_dir }}/scripts/run_prometheus.sh
+Restart=on-failure
+User={{ deploy_user }}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/prometheus/templates/run_prometheus.sh.j2
+++ b/roles/prometheus/templates/run_prometheus.sh.j2
@@ -2,12 +2,16 @@
 set -e
 ulimit -n 1000000
 
+DEPLOY_DIR={{ deploy_dir }}
+cd "${DEPLOY_DIR}" || exit 1
+
 {% set my_ip = hostvars[inventory_hostname].ansible_host | default(hostvars[inventory_hostname].inventory_hostname) -%}
 
 # WARNING: This file was auto-generated. Do not edit!
 #          All your edit might be overwritten!
 exec > >(tee -i -a "{{ prometheus_log_dir }}/{{ prometheus_log_filename }}")
 exec 2>&1
+
 
 exec bin/prometheus \
     --config.file="{{ deploy_dir }}/conf/prometheus.yml" \

--- a/roles/pump/tasks/main.yml
+++ b/roles/pump/tasks/main.yml
@@ -28,6 +28,23 @@
   vars:
     role_status_dir: status/{{ role_name }}
 
+- name: create systemd service configuration
+  template:
+    src: "pump.service.j2"
+    dest: "/etc/systemd/system/pump.service"
+    mode: 0644
+  when: use_systemd
+  vars:
+    - ansible_become: false
+    - ansible_become_user: root
+
+- name: reload systemd
+  shell: "systemctl daemon-reload"
+  when: use_systemd
+  vars:
+    - ansible_become: false
+    - ansible_become_user: root
+
 - name: prepare firewalld white list
   set_fact:
     firewalld_ports: "{{ [pump_port ~ '/tcp'] + firewalld_ports }}"

--- a/roles/pump/templates/pump.service.j2
+++ b/roles/pump/templates/pump.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Pump Service
+After=syslog.target network.target remote-fs.target nss-lookup.target
+
+[Service]
+LimitNOFILE=1000000
+ExecStart={{ deploy_dir }}/scripts/run_pump.sh
+Restart=on-failure
+User={{ deploy_user }}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/pump/templates/run_pump.sh.j2
+++ b/roles/pump/templates/run_pump.sh.j2
@@ -2,6 +2,9 @@
 set -e
 ulimit -n 1000000
 
+DEPLOY_DIR={{ deploy_dir }}
+cd "${DEPLOY_DIR}" || exit 1
+
 # WARNING: This file was auto-generated. Do not edit!
 #          All your edit might be overwritten!
 {% set my_ip = hostvars[inventory_hostname].ansible_host | default(hostvars[inventory_hostname].inventory_hostname) -%}

--- a/roles/pushgateway/tasks/main.yml
+++ b/roles/pushgateway/tasks/main.yml
@@ -26,6 +26,23 @@
   vars:
     role_status_dir: status/{{ role_name }}
 
+- name: create systemd service configuration
+  template:
+    src: "push-gateway.service.j2"
+    dest: "/etc/systemd/system/push-gateway.service"
+    mode: 0644
+  when: use_systemd
+  vars:
+    - ansible_become: false
+    - ansible_become_user: root
+
+- name: reload systemd
+  shell: "systemctl daemon-reload"
+  when: use_systemd
+  vars:
+    - ansible_become: false
+    - ansible_become_user: root
+
 - name: prepare firewalld white list
   set_fact:
     firewalld_ports: "{{ [pushgateway_port ~ '/tcp'] + firewalld_ports }}"

--- a/roles/pushgateway/templates/push-gateway.service.j2
+++ b/roles/pushgateway/templates/push-gateway.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Push Gateway Service
+After=syslog.target network.target remote-fs.target nss-lookup.target
+
+[Service]
+LimitNOFILE=1000000
+ExecStart={{ deploy_dir }}/scripts/run_pushgateway.sh
+Restart=on-failure
+User={{ deploy_user }}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/pushgateway/templates/run_pushgateway.sh.j2
+++ b/roles/pushgateway/templates/run_pushgateway.sh.j2
@@ -2,6 +2,9 @@
 set -e
 ulimit -n 1000000
 
+DEPLOY_DIR={{ deploy_dir }}
+cd "${DEPLOY_DIR}" || exit 1
+
 # WARNING: This file was auto-generated. Do not edit!
 #          All your edit might be overwritten!
 exec > >(tee -i -a "{{ pushgateway_log_dir }}/{{ pushgateway_log_filename }}")

--- a/roles/tidb/tasks/main.yml
+++ b/roles/tidb/tasks/main.yml
@@ -62,6 +62,23 @@
   command: mv "{{ tidb_script.backup_file }}" "{{ backup_dir }}"
   when: tidb_script.changed and tidb_script.backup_file is defined
 
+- name: create systemd service configuration
+  template:
+    src: "tidb.service.j2"
+    dest: "/etc/systemd/system/tidb.service"
+    mode: 0644
+  when: use_systemd
+  vars:
+    - ansible_become: false
+    - ansible_become_user: root
+
+- name: reload systemd
+  shell: "systemctl daemon-reload"
+  when: use_systemd
+  vars:
+    - ansible_become: false
+    - ansible_become_user: root
+
 - name: prepare firewalld white list
   set_fact:
     firewalld_ports: "{{ [tidb_port ~ '/tcp', tidb_status_port ~ '/tcp'] + firewalld_ports }}"

--- a/roles/tidb/templates/tidb.service.j2
+++ b/roles/tidb/templates/tidb.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=TiDB Service
+After=syslog.target network.target remote-fs.target nss-lookup.target
+
+[Service]
+LimitNOFILE=1000000
+ExecStart={{ deploy_dir }}/scripts/run_tidb.sh
+Restart=on-failure
+User={{ deploy_user }}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/tikv/tasks/main.yml
+++ b/roles/tikv/tasks/main.yml
@@ -73,6 +73,23 @@
   command: mv "{{ tikv_script.backup_file }}" "{{ backup_dir }}"
   when: tikv_script.changed and tikv_script.backup_file is defined
 
+- name: create systemd service configuration
+  template:
+    src: "tikv.service.j2"
+    dest: "/etc/systemd/system/tikv.service"
+    mode: 0644
+  when: use_systemd
+  vars:
+    - ansible_become: false
+    - ansible_become_user: root
+
+- name: reload systemd
+  shell: "systemctl daemon-reload"
+  when: use_systemd
+  vars:
+    - ansible_become: false
+    - ansible_become_user: root
+
 - name: prepare firewalld white list
   set_fact:
     firewalld_ports: "{{ [tikv_port ~ '/tcp'] + firewalld_ports }}"

--- a/roles/tikv/templates/tikv.service.j2
+++ b/roles/tikv/templates/tikv.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=TiKV Service
+After=syslog.target network.target remote-fs.target nss-lookup.target
+
+[Service]
+LimitNOFILE=1000000
+ExecStart={{ deploy_dir }}/scripts/run_tikv.sh
+Restart=on-failure
+User={{ deploy_user }}
+
+[Install]
+WantedBy=multi-user.target

--- a/rolling_update.yml
+++ b/rolling_update.yml
@@ -43,6 +43,16 @@
       tags:
         - restart
       shell: cd {{ deploy_dir }}/scripts && ./stop_node_exporter.sh
+      when: not use_systemd
+
+    - name: stop NodeExporter by systemd
+      tags:
+        - restart
+      systemd: name=node-exporter.service state=stopped
+      when: use_systemd
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
 
     - name: wait NodeExporter down
       tags:
@@ -53,6 +63,16 @@
       tags:
         - restart
       shell: cd {{ deploy_dir }}/scripts && ./start_node_exporter.sh
+      when: not use_systemd
+
+    - name: start NodeExporter by systemd
+      tags:
+        - restart
+      systemd: name=node-exporter.service state=restarted
+      when: use_systemd
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
 
     - name: wait NodeExporter up
       wait_for: |
@@ -73,6 +93,16 @@
       tags:
         - restart
       shell: cd {{ deploy_dir }}/scripts && ./stop_pd.sh
+      when: not use_systemd
+
+    - name: stop PD by systemd
+      tags:
+        - restart
+      systemd: name=pd.service state=stopped
+      when: use_systemd
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
 
     - name: wait PD down
       tags:
@@ -83,6 +113,16 @@
       tags:
         - restart
       shell: cd {{ deploy_dir }}/scripts && ./start_pd.sh
+      when: not use_systemd
+
+    - name: start PD by systemd
+      tags:
+        - restart
+      systemd: name=pd.service state=started
+      when: use_systemd
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
 
     - name: wait PD up
       wait_for: |
@@ -103,6 +143,16 @@
       tags:
         - restart
       shell: cd {{ deploy_dir }}/scripts && ./stop_tikv.sh
+      when: not use_systemd
+
+    - name: stop TiKV by systemd
+      tags:
+        - restart
+      systemd: name=tikv.service state=stopped
+      when: use_systemd
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
 
     - name: wait TiKV down (via Port)
       tags:
@@ -112,12 +162,23 @@
     - name: wait TiKV down (via PID)
       tags:
         - restart
+      when: not use_systemd
       wait_for_pid: pid_file={{ deploy_dir }}/status/tikv.pid timeout=300 state=absent
 
     - name: start TiKV
       tags:
         - restart
       shell: cd {{ deploy_dir }}/scripts && ./start_tikv.sh
+      when: not use_systemd
+
+    - name: start TiKV by systemd
+      tags:
+        - restart
+      systemd: name=tikv.service state=started
+      when: use_systemd
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
 
     - name: wait TiKV up
       tags:
@@ -141,17 +202,34 @@
       tags:
         - restart
       shell: cd {{ deploy_dir }}/scripts && ./stop_tidb.sh
+      when: not use_systemd
+
+    - name: stop TiDB by systemd
+      tags:
+        - restart
+      systemd: name=tidb.service state=stopped
+      when: use_systemd
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
 
     - name: wait TiDB down
       tags:
         - restart
       wait_for: host={{ ansible_host }} port={{ tidb_port }} state=stopped
 
-    - name: pump
+    - name: stop pump
       shell: cd {{ deploy_dir }}/scripts && (./stop_{{ item }}.sh; ./start_{{ item }}.sh)
       with_items:
         - pump
-      when: enable_binlog
+      when: enable_binlog and not use_systemd
+
+    - name: stop pump by systemd
+      systemd: name=pump.service state=stopped
+      when: enable_binlog and use_systemd
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
 
     - name: wait pump up
       wait_for: |
@@ -162,6 +240,16 @@
       tags:
         - restart
       shell: cd {{ deploy_dir }}/scripts && ./start_tidb.sh
+      when: not use_systemd
+
+    - name: start TiDB by systemd
+      tags:
+        - restart
+      systemd: name=tidb.service state=started
+      when: use_systemd
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
 
     - name: wait TiDB up
       tags:

--- a/scripts/grafana-config-copy.py
+++ b/scripts/grafana-config-copy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from __future__ import print_function, \
     unicode_literals

--- a/start.yml
+++ b/start.yml
@@ -34,8 +34,17 @@
   tasks:
     - name: restart node_exporter
       shell: cd {{ deploy_dir }}/scripts && (./stop_{{ item }}.sh; ./start_{{ item }}.sh)
+      when: not use_systemd
       with_items:
-      - node_exporter
+        - node_exporter
+
+    - name: restart node_exporter by systemd
+      systemd: name=node-exporter.service state=started
+      when: use_systemd
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
+
     - name: wait up
       wait_for: |
         host={{ ansible_host }} port={{ node_exporter_port }} state=present
@@ -48,13 +57,26 @@
   tasks:
     - name: restart monitoring modules
       shell: cd {{ deploy_dir }}/scripts && (./stop_{{ item }}.sh; ./start_{{ item }}.sh)
+      when: not use_systemd
       with_items:
         - pushgateway
         - prometheus
+
+    - name: restart monitoring modules by systemd
+      systemd: name={{ item }} state=started
+      when: use_systemd
+      with_items:
+        - push-gateway.service
+        - prometheus.service
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
+
     - name: wait pushgateway up
       wait_for: |
         host={{ ansible_host }} port={{ pushgateway_port }} state=present
         send='GET /metrics HTTP/1.0\r\n\r\n' search_regex='200 OK'
+
     - name: wait prometheus up
       wait_for: |
         host={{ ansible_host }} port={{ prometheus_port }} state=present
@@ -66,8 +88,17 @@
   tasks:
     - name: restart PD
       shell: cd {{ deploy_dir }}/scripts && ./start_{{ item }}.sh
+      when: not use_systemd
       with_items:
         - pd
+
+    - name: restart PD by systemd
+      systemd: name=pd.service state=started
+      when: use_systemd
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
+
     - name: wait up
       wait_for: |
         host={{ ansible_host }} port={{ pd_client_port }} state=present
@@ -79,8 +110,17 @@
   tasks:
     - name: restart TiKV
       shell: cd {{ deploy_dir }}/scripts && ./start_{{ item }}.sh
+      when: not use_systemd
       with_items:
         - tikv
+
+    - name: restart TiKV by systemd
+      systemd: name=tikv.service state=started
+      when: use_systemd
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
+
     - name: wait up
       wait_for_pid: |
         pid_file={{ deploy_dir }}/status/tikv.pid timeout=300
@@ -96,9 +136,16 @@
 
     - name: start pump
       shell: cd {{ deploy_dir }}/scripts && ./start_{{ item }}.sh
+      when: enable_binlog and not use_systemd
       with_items:
         - pump
-      when: enable_binlog
+
+    - name: start pump by systemd
+      systemd: name=pump.service state=started
+      when: enable_binlog and use_systemd
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
 
     - name: wait pump up
       wait_for: |
@@ -107,8 +154,17 @@
 
     - name: restart TiDB
       shell: cd {{ deploy_dir }}/scripts && ./start_{{ item }}.sh
+      when: not use_systemd
       with_items:
         - tidb
+
+    - name: restart TiDB by systemd
+      systemd: name=tidb.service state=started
+      when: use_systemd
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
+
     - name: wait up
       wait_for: |
         host={{ ansible_host }} port={{ tidb_port }} state=present
@@ -122,8 +178,16 @@
   tasks:
     - name: restart grafana
       shell: cd {{ deploy_dir }}/scripts && (./stop_{{ item }}.sh; ./start_{{ item }}.sh)
+      when: not use_systemd
       with_items:
         - grafana
+
+    - name: restart grafana by systemd
+      systemd: name=grafana.service state=started
+      when: use_systemd
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
 
     - name: wait grafana up
       wait_for: |

--- a/stop.yml
+++ b/stop.yml
@@ -36,7 +36,15 @@
     - name: stop node_exporter
       shell: cd {{ deploy_dir }}/scripts && ./stop_{{ item }}.sh
       with_items:
-      - node_exporter
+        - node_exporter
+      when: not use_systemd
+
+    - name: stop node_exporter by systemd
+      systemd: name=node-exporter.service state=stopped
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
+      when: use_systemd
 
 - hosts: monitoring_servers
   tags:
@@ -48,6 +56,17 @@
       with_items:
         - pushgateway
         - prometheus
+      when: not use_systemd
+
+    - name: stop monitoring modules by systemd
+      systemd: name={{ item }} state=stopped
+      with_items:
+        - push-gateway.service
+        - prometheus.service
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
+      when: use_systemd
 
 - hosts: pd_servers
   tags:
@@ -55,8 +74,16 @@
   tasks:
     - name: stop PD
       shell: cd {{ deploy_dir }}/scripts && ./stop_{{ item }}.sh
+      when: not use_systemd
       with_items:
         - pd
+
+    - name: stop PD by systemd
+      systemd: name=pd.service state=stopped
+      when: use_systemd
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
 
 - hosts: tikv_servers
   tags:
@@ -64,8 +91,16 @@
   tasks:
     - name: stop TiKV
       shell: cd {{ deploy_dir }}/scripts && ./stop_{{ item }}.sh
+      when: not use_systemd
       with_items:
         - tikv
+
+    - name: stop TiKV by systemd
+      systemd: name=tikv.service state=stopped
+      when: use_systemd
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
 
 - hosts: tidb_servers
   tags:
@@ -73,14 +108,29 @@
   tasks:
     - name: stop TiDB
       shell: cd {{ deploy_dir }}/scripts && ./stop_{{ item }}.sh
+      when: not use_systemd
       with_items:
         - tidb
 
+    - name: stop TiDB by systemd
+      systemd: name=tidb.service state=stopped
+      when: use_systemd
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
+
     - name: stop pump
       shell: cd {{ deploy_dir }}/scripts && ./stop_{{ item }}.sh
+      when: enable_binlog and not use_systemd
       with_items:
         - pump
-      when: enable_binlog
+
+    - name: stop pump by systemd
+      systemd: name=pump.service state=stopped
+      when: enable_binlog and use_systemd
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root
 
 - hosts: grafana_servers
   # FIXME: must introduce this to load all variables
@@ -89,5 +139,13 @@
   tasks:
     - name: stop monitoring modules
       shell: cd {{ deploy_dir }}/scripts && ./stop_{{ item }}.sh
+      when: not use_systemd
       with_items:
         - grafana
+
+    - name: stop monitoring modules by systemd
+      systemd: name=grafana.service state=stopped
+      when: use_systemd
+      vars:
+        - ansible_become: false
+        - ansible_become_user: root


### PR DESCRIPTION
Use systemd to track daemons instead supervisord, add variable use_systemd on inventory.ini, when set `use_systemd=True` will use systemd to manage services.

This PR is tested on Ubuntu and CentOS

When use systemd user must make sure systemd must be installed. 
+ Ubuntu higher than 14.04 systemd is installed by default.
+ CentOS higher than 7 systemd is installed by default.