### PR TITLE
update tispark jar address

### DIFF
--- a/roles/local/templates/binary_packages.yml.j2
+++ b/roles/local/templates/binary_packages.yml.j2
@@ -41,7 +41,7 @@ tispark_packages:
     version: 2.1.1
     url: http://download.pingcap.org/spark-2.1.1-bin-hadoop2.7.tgz
   - name: tispark-SNAPSHOT-jar-with-dependencies.jar
-    url: http://download.pingcap.org/tispark-SNAPSHOT-jar-with-dependencies.jar
+    url: http://download.pingcap.org/tispark-0.1.0-SNAPSHOT-jar-with-dependencies.jar
   - name: tispark-sample-data.tar.gz
     version: 0.1.0-beta
     url: http://download.pingcap.org/tispark-sample-data.tar.gz


### PR DESCRIPTION
The old download link for tispark jar should be replaced.
@LinuxGit  @xuechunL PTAL. 