### PR TITLE
scripts: Ensure the interpreter is python2

### DIFF
--- a/scripts/grafana-config-copy.py
+++ b/scripts/grafana-config-copy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from __future__ import print_function, \
     unicode_literals


### PR DESCRIPTION
The `scripts/grafana-config-copy.py` script is executed on the Control Machine and is written in python2. However, not all Linux distributions use python2 by default (such as Arch Linux), and thus wrongly pick python3 for the script.

With this fix, I can successfully provision TiDB with Arch Linux on the Control Machine (the other machines still used CentOS).