### PR TITLE
fix  port can not reuse

### DIFF
--- a/roles/bootstrap/tasks/root_tasks.yml
+++ b/roles/bootstrap/tasks/root_tasks.yml
@@ -18,6 +18,9 @@
     - { name: 'vm.swappiness', value: 0 }
     - { name: 'net.ipv4.tcp_syncookies', value: 0 }
     - { name: 'fs.file-max', value: 1000000 }
+    - { name: 'net.ipv4.tcp_tw_reuse', value: 1 }
+    - { name: 'net.ipv4.tcp_tw_recycle', value: 1 }
+    - { name: 'net.ipv4.tcp_timestamps', value: 1 }
   when: tuning_kernel_parameters
 
 - name: update /etc/security/limits.conf


### PR DESCRIPTION
fix  port can not reuse

```
2018/03/01 19:09:25.835 redirector.go:106: [error] Get http://10.1.0.5:2379/pd/api/v1/stores: dial tcp 10.1.0.5:2379: connect: cannot assign requested address
2018/03/01 19:09:25.835 redirector.go:106: [error] Get http://10.1.0.5:2379/pd/health: dial tcp 10.1.0.5:2379: connect: cannot assign requested address
2018/03/01 19:09:25.885 redirector.go:106: [error] Get http://10.1.0.5:2379/pd/api/v1/stores: dial tcp 10.1.0.5:2379: connect: cannot assign requested address
2018/03/01 19:09:25.892 redirector.go:106: [error] Get http://10.1.0.5:2379/pd/ping: dial tcp 10.1.0.5:2379: connect: cannot assign requested address
2018/03/01 19:09:25.919 redirector.go:106: [error] Get http://10.1.0.5:2379/pd/health: dial tcp 10.1.0.5:2379: connect: cannot assign requested address
2018/03/01 19:09:25.934 redirector.go:106: [error] Get http://10.1.0.5:2379/pd/api/v1/stores: dial tcp 10.1.0.5:2379: connect: cannot assign requested address
```