### PR TITLE
readpool -> readpool.storage

### DIFF
--- a/conf/tikv.yml
+++ b/conf/tikv.yml
@@ -6,20 +6,21 @@ global:
   # log-level: "info"
 
 readpool:
-  # size of thread pool for high-priority read operations
-  # high-concurrency: 8
-  # size of thread pool for normal-priority read operations
-  # normal-concurrency: 8
-  # size of thread pool for low-priority read operations
-  # low-concurrency: 8
-  # max running high-priority read operations, reject if exceed
-  # max-tasks-high: 16000
-  # max running normal-priority read operations, reject if exceed
-  # max-tasks-normal: 16000
-  # max running low-priority read operations, reject if exceed
-  # max-tasks-low: 16000
-  # size of stack size for each thread pool
-  # stack-size: "10MB"
+  storage:
+    # size of thread pool for high-priority read operations
+    # high-concurrency: 8
+    # size of thread pool for normal-priority read operations
+    # normal-concurrency: 8
+    # size of thread pool for low-priority read operations
+    # low-concurrency: 8
+    # max running high-priority read operations, reject if exceed
+    # max-tasks-high: 16000
+    # max running normal-priority read operations, reject if exceed
+    # max-tasks-normal: 16000
+    # max running low-priority read operations, reject if exceed
+    # max-tasks-low: 16000
+    # size of stack size for each thread pool
+    # stack-size: "10MB"
 
 server:
   # set advertise listening address for client communication, if not set, use addr instead.

--- a/roles/tikv/templates/tikv.toml.j2
+++ b/roles/tikv/templates/tikv.toml.j2
@@ -9,8 +9,8 @@
 {{ item }} = {{ value | to_json }}
 {% endfor %}
 
-[readpool]
-{% for item, value in tikv_conf.readpool | dictsort -%}
+[readpool.storage]
+{% for item, value in tikv_conf.readpool.storage | dictsort -%}
 {{ item }} = {{ value | to_json }}
 {% endfor %}
 

--- a/roles/tikv/vars/default.yml
+++ b/roles/tikv/vars/default.yml
@@ -6,20 +6,21 @@ global:
   # log-level: "info"
 
 readpool:
-  # size of thread pool for high-priority read operations
-  # high-concurrency: 8
-  # size of thread pool for normal-priority read operations
-  # normal-concurrency: 8
-  # size of thread pool for low-priority read operations
-  # low-concurrency: 8
-  # max running high-priority read operations, reject if exceed
-  # max-tasks-high: 16000
-  # max running normal-priority read operations, reject if exceed
-  # max-tasks-normal: 16000
-  # max running low-priority read operations, reject if exceed
-  # max-tasks-low: 16000
-  # size of stack size for each thread pool
-  # stack-size: "10MB"
+  storage:
+    # size of thread pool for high-priority read operations
+    # high-concurrency: 8
+    # size of thread pool for normal-priority read operations
+    # normal-concurrency: 8
+    # size of thread pool for low-priority read operations
+    # low-concurrency: 8
+    # max running high-priority read operations, reject if exceed
+    # max-tasks-high: 16000
+    # max running normal-priority read operations, reject if exceed
+    # max-tasks-normal: 16000
+    # max running low-priority read operations, reject if exceed
+    # max-tasks-low: 16000
+    # size of stack size for each thread pool
+    # stack-size: "10MB"
 
 server:
   # set listening address.


### PR DESCRIPTION
We will have coprocessor read pool soon, so that config of these two need to be separated.

Related TiKV PR: https://github.com/pingcap/tikv/pull/2813