### PR TITLE
script: update grafana add a "failed query" panel

### DIFF
--- a/scripts/tidb.json
+++ b/scripts/tidb.json
@@ -521,6 +521,140 @@
               "show": true
             }
           ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${DS_TEST-CLUSTER}",
+            "editable": true,
+            "error": false,
+            "fill": 0,
+            "grid": {},
+            "id": 92,
+            "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": true,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "sideWidth": 250,
+                "sort": "max",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "minSpan": 12,
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                "alias": "total",
+                "lines": false
+                }
+            ],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "sum(increase(tidb_server_execute_error_total[1m])) by (type)",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": " {{type}}",
+                "refId": "A",
+                "step": 30
+                }
+            ],
+            "thresholds": [
+                {
+                "value": null,
+                "op": "gt",
+                "fill": true,
+                "line": true,
+                "colorMode": "critical"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Failed Query",
+            "tooltip": {
+                "msResolution": true,
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "short",
+                "label": null,
+                "logBase": 2,
+                "max": null,
+                "min": "0",
+                "show": true
+                },
+                {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+                }
+            ],
+            "alert": {
+                "conditions": [
+                {
+                    "type": "query",
+                    "query": {
+                    "params": [
+                        "A",
+                        "5m",
+                        "now"
+                    ]
+                    },
+                    "reducer": {
+                    "type": "avg",
+                    "params": []
+                    },
+                    "evaluator": {
+                    "type": "gt",
+                    "params": [
+                        null
+                    ]
+                    },
+                    "operator": {
+                    "type": "and"
+                    }
+                }
+                ],
+                "noDataState": "no_data",
+                "executionErrorState": "alerting",
+                "frequency": "60s",
+                "handler": 1,
+                "notifications": [],
+                "name": "Failed Query alert"
+            }
         }
       ],
       "repeat": null,
@@ -867,6 +1001,88 @@
               "show": true
             }
           ]
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${DS_TEST-CLUSTER}",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {},
+            "id": 93,
+            "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "max": true,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "increase(tidb_server_execute_error_total[1m])",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{type}} @ {{instance}}",
+                "refId": "A",
+                "step": 60
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Failed Query Detail",
+            "tooltip": {
+                "msResolution": true,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "none",
+                "label": null,
+                "logBase": 2,
+                "max": null,
+                "min": "0.001",
+                "show": true
+                },
+                {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+                }
+            ]
         }
       ],
       "repeat": null,

--- a/scripts/tidb.json
+++ b/scripts/tidb.json
@@ -1012,7 +1012,7 @@
             "error": false,
             "fill": 1,
             "grid": {},
-            "id": 93,
+            "id": 94,
             "legend": {
                 "alignAsTable": true,
                 "avg": false,
@@ -1057,7 +1057,7 @@
                 "sort": 0,
                 "value_type": "cumulative"
             },
-
+            "type": "graph",
             "xaxis": {
                 "buckets": null,
                 "mode": "time",


### PR DESCRIPTION
Those query errors would return to client, when we find them in the grafana panel, we should check the log to see details.
And we'll should also add alert rules for them.

![image](https://user-images.githubusercontent.com/1420062/38733261-d7d3bff8-3ee6-11e8-8475-43c2871071db.png)

@coocood @shenli 