### PR TITLE
Louis/download

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -26,4 +26,4 @@ retry_stagger: 5
 dev_mode: False
 
 # deployment methods, [binary, docker] docker deployment method is not recommended and deprecated.
-deployment_method = binary
+deployment_method: binary

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -24,3 +24,6 @@ docker_bin_dir: "/usr/bin"
 retry_stagger: 5
 
 dev_mode: False
+
+# deployment methods, [binary, docker] docker deployment method is not recommended and deprecated.
+deployment_method = binary

--- a/inventory.ini
+++ b/inventory.ini
@@ -57,9 +57,6 @@ cluster_name = test-cluster
 
 tidb_version = latest
 
-# deployment methods, [binary, docker]
-deployment_method = binary
-
 # process supervision, [systemd, supervise]
 process_supervision = systemd
 

--- a/local_prepare.yml
+++ b/local_prepare.yml
@@ -3,6 +3,5 @@
 - name: do local preparation
   hosts: localhost
   connection: local
-  gather_facts: false
   roles:
     - local

--- a/local_prepare.yml
+++ b/local_prepare.yml
@@ -3,5 +3,6 @@
 - name: do local preparation
   hosts: localhost
   connection: local
+  gather_facts: true
   roles:
     - local

--- a/roles/local/tasks/binary_deployment.yml
+++ b/roles/local/tasks/binary_deployment.yml
@@ -40,7 +40,7 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   with_items: "{{ tispark_packages }}"
-  when: has_outbound_network
+  when: has_outbound_network and not deploy_without_tidb|default(false)
 
 - name: unarchive third party binary
   shell: ls -1 {{ item.name }}-{{ item.version }}.tar.gz | xargs -n1 tar xzf
@@ -54,6 +54,7 @@
   args:
     chdir: "{{ downloads_dir }}"
     warn: no
+  when: not deploy_without_tidb|default(false)
 
 - name: cp monitoring binary
   shell: >
@@ -68,3 +69,4 @@
 - name: cp tispark-sample-data
   shell: >
     cp -rfv {{ downloads_dir }}/tispark-sample-data "{{ resources_dir }}/bin/"
+  when: not deploy_without_tidb|default(false)

--- a/roles/local/tasks/binary_deployment.yml
+++ b/roles/local/tasks/binary_deployment.yml
@@ -12,7 +12,9 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   with_items: "{{ third_party_packages }}"
-  when: has_outbound_network and not under_gfw
+  when:
+    - has_outbound_network
+    - not under_gfw
 
 - name: download other binary under gfw
   get_url:
@@ -26,7 +28,9 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   with_items: "{{ third_party_packages_under_gfw }}"
-  when: has_outbound_network and under_gfw
+  when:
+    - has_outbound_network
+    - under_gfw
 
 - name: download TiSpark packages
   get_url:
@@ -40,7 +44,9 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   with_items: "{{ tispark_packages }}"
-  when: has_outbound_network and not deploy_without_tidb|default(false)
+  when:
+    - has_outbound_network
+    - not deploy_without_tidb|default(false)
 
 - name: unarchive third party binary
   shell: ls -1 {{ item.name }}-{{ item.version }}.tar.gz | xargs -n1 tar xzf

--- a/roles/local/tasks/main.yml
+++ b/roles/local/tasks/main.yml
@@ -6,6 +6,24 @@
       - ansible_version.full|version_compare('2.4.2', '>=')
       # - ansible_version.full is version('2.5.0', '>=')
 
+- name: Redhat/CentOS - Make sure curl have been installed
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - curl
+  become: true
+  when: ansible_distribution in ['RedHat', 'CentOS']
+
+- name: Debian/Ubuntu - Make sure curl have been installed
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - curl
+  become: true
+  when: ansible_distribution in ['Debian', 'Ubuntu']
+
 - name: create downloads and resources directories
   file: path="{{ item }}" state=directory mode=0755
   with_items:

--- a/roles/local/tasks/main.yml
+++ b/roles/local/tasks/main.yml
@@ -6,23 +6,13 @@
       - ansible_version.full|version_compare('2.4.2', '>=')
       # - ansible_version.full is version('2.5.0', '>=')
 
-- name: Redhat/CentOS - Make sure curl have been installed
-  yum:
+- name: Make sure curl have been installed
+  package:
     name: "{{ item }}"
     state: present
   with_items:
     - curl
   become: true
-  when: ansible_distribution in ['RedHat', 'CentOS']
-
-- name: Debian/Ubuntu - Make sure curl have been installed
-  apt:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - curl
-  become: true
-  when: ansible_distribution in ['Debian', 'Ubuntu']
 
 - name: create downloads and resources directories
   file: path="{{ item }}" state=directory mode=0755
@@ -110,7 +100,9 @@
   until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  when: has_outbound_network and enable_tls|default(false)
+  when:
+    - has_outbound_network
+    - enable_tls|default(false)
 
 - name: download cfssljson binary
   get_url:
@@ -123,7 +115,9 @@
   until: "'OK' in get_url_result.msg or 'file already exists' in get_url_result.msg"
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
-  when: has_outbound_network and enable_tls|default(false)
+  when:
+    - has_outbound_network
+    - enable_tls|default(false)
 
 - include_tasks: "{{ deployment_method }}_deployment.yml"
 

--- a/roles/local/templates/binary_packages.yml.j2
+++ b/roles/local/templates/binary_packages.yml.j2
@@ -42,6 +42,7 @@ third_party_packages_under_gfw:
     url: "http://download.pingcap.org/blackbox_exporter-0.12.0.linux-amd64.tar.gz"
 
 
+{% if not deploy_without_tidb|default(false) %}
 tispark_packages:
   - name: spark-2.1.1-bin-hadoop2.7.tgz
     version: 2.1.1
@@ -52,3 +53,4 @@ tispark_packages:
   - name: tispark-sample-data.tar.gz
     version: 0.1.0-beta
     url: http://download.pingcap.org/tispark-sample-data.tar.gz
+{% endif %}

--- a/roles/local/templates/common_packages.yml.j2
+++ b/roles/local/templates/common_packages.yml.j2
@@ -4,11 +4,8 @@ tidb_packages:
   - name: tidb
     version: {{ tidb_version }}
     url: http://download.pingcap.org/tidb-{{ tidb_version }}-linux-amd64-unportable.tar.gz
+{% if not deploy_without_tidb|default(false) %}
   - name: tidb-binlog
-{% if tidb_version == 'rc2.2' %}
-    version: rc2.2
-    url: http://download.pingcap.org/tidb-binlog-rc2.2-linux-amd64.tar.gz
-{% else %}
     version: latest
     url: http://download.pingcap.org/tidb-binlog-latest-linux-amd64.tar.gz
 {% endif %}
@@ -20,6 +17,7 @@ common_packages:
   - name: fio
     version: 2.16
     url: "http://download.pingcap.org/fio-2.16.tar.gz"
+    checksum: "sha256:bb8e2413aaa154e4b738c5f79a346353ae993c93632d93ad316fcfa70eaa4d04"
   - name: grafana_collector
     version: latest
     url: http://download.pingcap.org/grafana_collector-latest-linux-amd64.tar.gz
@@ -27,4 +25,5 @@ common_packages:
   - name: daemontools
     version: 0.53
     url: http://download.pingcap.org/daemontools-0.53.tar.gz
+    checksum: "sha256:a4abd491cf185aef5644be5a4e1ed52c8f458802178d4c0efcc8178a5ca67fb7"
 {% endif %}


### PR DESCRIPTION
- add checksum for supervise and fio packages
- don't downloading tispark when setting deploy_without_tidb = True
- make sure curl have been installed on control machine
- hide `deployment_method` variable , docker deployment method is not recommended and deprecated.
 
