### PR TITLE
add a python script to show the leader distribution of a table

### DIFF
--- a/scripts/table-regions.py
+++ b/scripts/table-regions.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+#!coding:utf-8
+
+import argparse
+import subprocess
+import json
+
+def main():
+    args = parse_args()
+    httpAPI = "http://{}:{}/tables/{}/{}/regions".format(args.host, args.port, args.database, args.table)
+
+    webContent = subprocess.check_output(["curl", "-sl", httpAPI])
+    region_info = json.loads(webContent)
+
+    table_region_leader = parse_regions(region_info["record_regions"])
+    indices_region_leader = []
+    for index_info in region_info["indices"]:
+        index_name = index_info["name"]
+        index_region_leader = parse_regions(index_info["regions"])
+        indices_region_leader.append({"name": index_name, "leader": index_region_leader})
+
+    print("region leader distribution for table \"{}.{}\":".format(args.database, args.table))
+    print_leader(table_region_leader)
+    for index_region_info in indices_region_leader:
+        print("region leader distribution for index \"{}\":".format(index_region_info["name"]))
+        print_leader(index_region_info["leader"])
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Show leader distribution of a TiDB table.")
+    parser.add_argument("--host", dest="host", help="tidb-server address, default: 127.0.0.1", default="127.0.0.1")
+    parser.add_argument("--port", dest="port", help="tidb-server status port, default: 10080", default="10080")
+    parser.add_argument("database", help="database name")
+    parser.add_argument("table",    help="table name")
+    args = parser.parse_args()
+    return args
+
+def parse_regions(regions):
+    info = {}
+    for region in regions:
+        if region["leader"]["store_id"] != None:
+            store_id = region["leader"]["store_id"]
+            info[store_id] = 1 + info.get(store_id, 0)
+    return info
+
+def print_leader(info, indent = "  "):
+    total_leaders = 0
+    for store_id, num_leaders in info.items():
+        total_leaders += num_leaders
+    print("{}total leader count: {}".format(indent, total_leaders))
+    for store_id, num_leaders in info.items():
+        print("{}store: {}, num_leaders: {}, percentage: {}%".format(indent, store_id, num_leaders, (num_leaders*100.0)/total_leaders))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Main Modification  
Add a python script **table-regions.py** to calculate the region leader distribution of a table in TiDB.

## Why Add This Script

1. To quickly identify whether a table or index has **only one** region
2. To quickly identify whether the leader distribution of table or index is balanced among all the tikv servers

## How to use
```sh
➜ ./scripts/table-regions.py -h
usage: table-regions.py [-h] [--host HOST] [--port PORT] database table

Show leader distribution of a TiDB table.

positional arguments:
  database     database name
  table        table name

optional arguments:
  -h, --help   show this help message and exit
  --host HOST  tidb-server address, default: 127.0.0.1
  --port PORT  tidb-server status port, default: 10080
```
 ## Example
```sh
➜ ./scripts/table-regions.py --host 172.16.10.16 tpch10 lineitem
region leader distribution for table "tpch10.lineitem":
  total leader count: 455
  store: 1, num_leaders: 159, percentage: 34.9450549451%
  store: 4, num_leaders: 144, percentage: 31.6483516484%
  store: 5, num_leaders: 152, percentage: 33.4065934066%
region leader distribution for index "PRIMARY":
  total leader count: 133
  store: 1, num_leaders: 48, percentage: 36.0902255639%
  store: 4, num_leaders: 43, percentage: 32.3308270677%
  store: 5, num_leaders: 42, percentage: 31.5789473684%
```