### PR TITLE
TiKV max-tasks-per-worker-xxx config

### DIFF
--- a/conf/tikv.yml
+++ b/conf/tikv.yml
@@ -15,11 +15,11 @@ readpool:
     # size of thread pool for low-priority read operations
     # low-concurrency: 4
     # max running high-priority operations of each worker, reject if exceed
-    # max-tasks-per-worker-high = 2000
+    # max-tasks-per-worker-high: 2000
     # max running normal-priority operations of each worker, reject if exceed
-    # max-tasks-per-worker-normal = 2000
+    # max-tasks-per-worker-normal: 2000
     # max running low-priority operations of each worker, reject if exceed
-    # max-tasks-per-worker-low = 2000
+    # max-tasks-per-worker-low: 2000
     # size of stack size for each thread pool
     # stack-size: "10MB"
   coprocessor:
@@ -28,9 +28,9 @@ readpool:
     # high-concurrency: 8
     # normal-concurrency: 8
     # low-concurrency: 8
-    # max-tasks-per-worker-high = 2000
-    # max-tasks-per-worker-normal = 2000
-    # max-tasks-per-worker-low = 2000
+    # max-tasks-per-worker-high: 2000
+    # max-tasks-per-worker-normal: 2000
+    # max-tasks-per-worker-low: 2000
     # stack-size: "10MB"
 
 server:

--- a/conf/tikv.yml
+++ b/conf/tikv.yml
@@ -14,12 +14,12 @@ readpool:
     # normal-concurrency: 4
     # size of thread pool for low-priority read operations
     # low-concurrency: 4
-    # max running high-priority read operations, reject if exceed
-    # max-tasks-high: 8000
-    # max running normal-priority read operations, reject if exceed
-    # max-tasks-normal: 8000
-    # max running low-priority read operations, reject if exceed
-    # max-tasks-low: 8000
+    # max running high-priority operations of each worker, reject if exceed
+    # max-tasks-per-worker-high = 2000
+    # max running normal-priority operations of each worker, reject if exceed
+    # max-tasks-per-worker-normal = 2000
+    # max running low-priority operations of each worker, reject if exceed
+    # max-tasks-per-worker-low = 2000
     # size of stack size for each thread pool
     # stack-size: "10MB"
   coprocessor:
@@ -28,9 +28,9 @@ readpool:
     # high-concurrency: 8
     # normal-concurrency: 8
     # low-concurrency: 8
-    # max-tasks-high: 16000
-    # max-tasks-normal: 16000
-    # max-tasks-low: 16000
+    # max-tasks-per-worker-high = 2000
+    # max-tasks-per-worker-normal = 2000
+    # max-tasks-per-worker-low = 2000
     # stack-size: "10MB"
 
 server:
@@ -49,9 +49,6 @@ server:
   # grpc-raft-conn-num: 10
   # Amount to read ahead on individual grpc streams.
   # grpc-stream-initial-window-size: "2MB"
-
-  # max count of tasks being handled, new tasks will be rejected.
-  # end-point-max-tasks: 2000
 
   # max recursion level allowed when decoding dag expression
   # end-point-recursion-limit: 1000

--- a/roles/tikv/vars/default.yml
+++ b/roles/tikv/vars/default.yml
@@ -14,12 +14,12 @@ readpool:
     # normal-concurrency: 4
     # size of thread pool for low-priority read operations
     # low-concurrency: 4
-    # max running high-priority read operations, reject if exceed
-    # max-tasks-high: 8000
-    # max running normal-priority read operations, reject if exceed
-    # max-tasks-normal: 8000
-    # max running low-priority read operations, reject if exceed
-    # max-tasks-low: 8000
+    # max running high-priority operations of each worker, reject if exceed
+    # max-tasks-per-worker-high = 2000
+    # max running normal-priority operations of each worker, reject if exceed
+    # max-tasks-per-worker-normal = 2000
+    # max running low-priority operations of each worker, reject if exceed
+    # max-tasks-per-worker-low = 2000
     # size of stack size for each thread pool
     # stack-size: "10MB"
   coprocessor:
@@ -28,9 +28,9 @@ readpool:
     # high-concurrency: 8
     # normal-concurrency: 8
     # low-concurrency: 8
-    # max-tasks-high: 16000
-    # max-tasks-normal: 16000
-    # max-tasks-low: 16000
+    # max-tasks-per-worker-high = 2000
+    # max-tasks-per-worker-normal = 2000
+    # max-tasks-per-worker-low = 2000
     # stack-size: "10MB"
 
 server:
@@ -51,9 +51,6 @@ server:
   # grpc-raft-conn-num: 10
   # Amount to read ahead on individual grpc streams.
   # grpc-stream-initial-window-size: "2MB"
-
-  # max count of tasks being handled, new tasks will be rejected.
-  # end-point-max-tasks: 2000
 
   # max recursion level allowed when decoding dag expression
   # end-point-recursion-limit: 1000

--- a/roles/tikv/vars/default.yml
+++ b/roles/tikv/vars/default.yml
@@ -15,11 +15,11 @@ readpool:
     # size of thread pool for low-priority read operations
     # low-concurrency: 4
     # max running high-priority operations of each worker, reject if exceed
-    # max-tasks-per-worker-high = 2000
+    # max-tasks-per-worker-high: 2000
     # max running normal-priority operations of each worker, reject if exceed
-    # max-tasks-per-worker-normal = 2000
+    # max-tasks-per-worker-normal: 2000
     # max running low-priority operations of each worker, reject if exceed
-    # max-tasks-per-worker-low = 2000
+    # max-tasks-per-worker-low: 2000
     # size of stack size for each thread pool
     # stack-size: "10MB"
   coprocessor:
@@ -28,9 +28,9 @@ readpool:
     # high-concurrency: 8
     # normal-concurrency: 8
     # low-concurrency: 8
-    # max-tasks-per-worker-high = 2000
-    # max-tasks-per-worker-normal = 2000
-    # max-tasks-per-worker-low = 2000
+    # max-tasks-per-worker-high: 2000
+    # max-tasks-per-worker-normal: 2000
+    # max-tasks-per-worker-low: 2000
     # stack-size: "10MB"
 
 server:


### PR DESCRIPTION
1. `max-tasks-xxx` is deprecated, `max-tasks-per-worker-xxx` is introduced.
2. `end-point-max-tasks` is deprecated, it will be inferred from `max-tasks-per-worker-xxx`.

~~Please merge this PR after https://github.com/pingcap/tikv/pull/3093 is merged.~~
