### PR TITLE
grafana: fix grafana key permission error

### DIFF
--- a/create_grafana_api_keys.yml
+++ b/create_grafana_api_keys.yml
@@ -17,6 +17,7 @@
   stat:
     path: "{{ grafana_api_keys_dir }}/grafana_apikey.key"
   register:  grafana_apikey_file
+  delegate_to: localhost
 
 - set_fact:
     apikey_id: "{{ item }}"


### PR DESCRIPTION
grafana:
When you put `tidb-ansible` in `/root`,  "Permission denied" error will occur when running "Check grafana API Key file existed" task. This pr will fix it. BTW. It's recommended to put `tidb-ansible` in `/home/tidb`.