### PR TITLE
Grafana screenshot with time range

### DIFF
--- a/scripts/grafana_pdf.py
+++ b/scripts/grafana_pdf.py
@@ -69,7 +69,8 @@ def parse_timestamp(time_string):
     ]
     for time_format in format_guess:
         try:
-            return time.mktime(time.strptime(time_string, time_format))
+            # Grafana API's timestamp is in ms
+            return time.mktime(time.strptime(time_string, time_format)) * 1000
         except ValueError:
             pass
     raise ValueError(

--- a/scripts/grafana_pdf.py
+++ b/scripts/grafana_pdf.py
@@ -37,7 +37,7 @@ def read_url(url):
         f = urlreq.urlopen(url)
         return f.read()
     except HTTPError as e:
-        print("HTTP Error: %s" % e.read())
+        print("HTTP Error: %s" % e.getcode())
         return e.read()
     except URLError as e:
         print("Reading URL %s error: %s" % (url, e))

--- a/scripts/grafana_pdf.py
+++ b/scripts/grafana_pdf.py
@@ -28,6 +28,17 @@ def make_tarfile(output_filename, source_dir):
     with tarfile.open(output_filename, "w:gz") as tar:
         tar.add(source_dir, arcname=os.path.basename(source_dir))
 
+def read_url(url):
+    try:
+        f = urlreq.urlopen(url)
+        return f.read()
+    except HTTPError as e:
+        print("HTTP Error: %s" % e.read())
+        return e.read()
+    except URLError as e:
+        print("Reading URL %s error: %s" % (url, e))
+        return None
+
 if __name__ == '__main__':
 
     if not os.path.isdir(download_dir):
@@ -42,8 +53,7 @@ if __name__ == '__main__':
             filename = "{0}.pdf".format(dest['titles'][dashboard])
 
             print("Downloading: ", filename)
-            f = urlreq.urlopen(url)
-            data = f.read()
+            data = read_url(url)
             with open(os.path.join(download_dir, filename), "wb") as pdf:
                 pdf.write(data)
 

--- a/scripts/grafana_pdf.py
+++ b/scripts/grafana_pdf.py
@@ -5,6 +5,7 @@ from __future__ import print_function, \
 
 import argparse
 import os
+import time
 import json
 import tarfile
 import shutil
@@ -45,9 +46,9 @@ def parse_opts():
     parser.add_argument("-t", "--time", action="store", default=None,
                         help="Relative time from now, supported format is like: 2h, 4h. If not set, assume 3h by default.")
     parser.add_argument("--time-from", action="store", default=None,
-                        help="Start timestamp of time range.")
+                        help="Start timestamp of time range, format: '%Y-%m-%d %H:%M:%S'.")
     parser.add_argument("--time-to", action="store", default=None,
-                        help="End timestamp of time range.")
+                        help="End timestamp of time range, format: '%Y-%m-%d %H:%M:%S'.")
     return parser.parse_args()
 
 if __name__ == '__main__':
@@ -58,10 +59,11 @@ if __name__ == '__main__':
     if args.time:
         time_args = "&from=now-{0}&to=now".format(args.time)
     elif args.time_from:
+        start_time = int(time.mktime(time.strptime(args.time_from, "%Y-%m-%d %H:%M:%S")))
         end_time = "now"
         if args.time_to:
-            end_time = args.time_to
-        time_args = "&from={0}&to={1}".format(args.time_from, end_time)
+            end_time = int(time.mktime(time.strptime(args.time_to, "%Y-%m-%d %H:%M:%S")))
+        time_args = "&from={0}&to={1}".format(start_time, end_time)
     else:
         time_args = "&from=now-3h&to=now"
 

--- a/scripts/grafana_pdf.py
+++ b/scripts/grafana_pdf.py
@@ -55,22 +55,22 @@ if __name__ == '__main__':
     if not os.path.isdir(download_dir):
         os.makedirs(download_dir)
 
+    if args.time:
+        time_args = "&from=now-{0}&to=now".format(args.time)
+    elif args.time_from:
+        end_time = "now"
+        if args.time_to:
+            end_time = args.time_to
+        time_args = "&from={0}&to={1}".format(args.time_from, end_time)
+    else:
+        time_args = "&from=now-3h&to=now"
+
     for dest in dests:
         report_url = dest['report_url']
         apikey = dest['apikey']
 
         for dashboard in dest['titles']:
-            url = "{0}api/report/{1}?apitoken={2}".format(report_url, dest['titles'][dashboard].lower(), apikey)
-            if args.time:
-                url = "{0}&from=now-{1}&to=now".format(url, args.time)
-            elif args.time_from:
-                end_time = "now"
-                if args.time_to:
-                    end_time = args.time_to
-                url = "{0}&from={1}&to={2}".format(url, args.time_from, end_time)
-            else:
-                url = "{0}&from=now-3h&to=now".format(url)
-
+            url = "{0}api/report/{1}?apitoken={2}{3}".format(report_url, dest['titles'][dashboard].lower(), apikey, time_args)
             filename = "{0}.pdf".format(dest['titles'][dashboard])
 
             print("Downloading: ", filename)

--- a/scripts/grafana_pdf.py
+++ b/scripts/grafana_pdf.py
@@ -61,6 +61,8 @@ def parse_timestamp(time_string):
         "%Y-%m-%d %H:%M:%S",
         "%Y-%m-%d %H:%M",
         "%Y-%m-%d %H",
+        "%Y-%m-%d",
+        "%m-%d",
         "%H:%M:%S",
         "%H:%M",
         "%H"

--- a/scripts/grafana_pdf.py
+++ b/scripts/grafana_pdf.py
@@ -1,13 +1,21 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from __future__ import print_function, \
     unicode_literals
 
 import os
-import urllib2
 import json
 import tarfile
 import shutil
+
+try:
+    # For Python 2
+    import urllib2 as urlreq
+    from urllib2 import HTTPError, URLError
+except ImportError:
+    # For Python 3
+    import urllib.request as urlreq
+    from urllib.error import HTTPError, URLError
 
 dests = []
 download_dir = "grafana_pdf"
@@ -34,7 +42,7 @@ if __name__ == '__main__':
             filename = "{0}.pdf".format(dest['titles'][dashboard])
 
             print("Downloading: ", filename)
-            f = urllib2.urlopen(url)
+            f = urlreq.urlopen(url)
             data = f.read()
             with open(os.path.join(download_dir, filename), "wb") as pdf:
                 pdf.write(data)

--- a/scripts/grafana_pdf.py
+++ b/scripts/grafana_pdf.py
@@ -26,9 +26,11 @@ if not dests:
     with open("./dests.json") as fp:
         dests = json.load(fp)
 
+
 def make_tarfile(output_filename, source_dir):
     with tarfile.open(output_filename, "w:gz") as tar:
         tar.add(source_dir, arcname=os.path.basename(source_dir))
+
 
 def read_url(url):
     try:
@@ -41,15 +43,18 @@ def read_url(url):
         print("Reading URL %s error: %s" % (url, e))
         return None
 
+
 def parse_opts():
-    parser = argparse.ArgumentParser(description="Export Grafana charts to PDF")
+    parser = argparse.ArgumentParser(
+        description="Export Grafana charts to PDF")
     parser.add_argument("-t", "--time", action="store", default=None,
-                        help="Relative time from now, supported format is like: 2h, 4h. If not set, assume 3h by default.")
+                        help="Relative time to now, supported format is like: 2h, 4h. If not set, assume 3h by default.")
     parser.add_argument("--time-from", action="store", default=None,
                         help="Start timestamp of time range, format: '%Y-%m-%d %H:%M:%S'.")
     parser.add_argument("--time-to", action="store", default=None,
                         help="End timestamp of time range, format: '%Y-%m-%d %H:%M:%S'.")
     return parser.parse_args()
+
 
 def parse_timestamp(time_string):
     format_guess = [
@@ -65,7 +70,9 @@ def parse_timestamp(time_string):
             return time.mktime(time.strptime(time_string, time_format))
         except ValueError:
             pass
-    raise ValueError("time data '%s' does not match any supported format." % time_string)
+    raise ValueError(
+        "time data '%s' does not match any supported format." % time_string)
+
 
 if __name__ == '__main__':
     args = parse_opts()
@@ -88,7 +95,8 @@ if __name__ == '__main__':
         apikey = dest['apikey']
 
         for dashboard in dest['titles']:
-            url = "{0}api/report/{1}?apitoken={2}{3}".format(report_url, dest['titles'][dashboard].lower(), apikey, time_args)
+            url = "{0}api/report/{1}?apitoken={2}{3}".format(
+                report_url, dest['titles'][dashboard].lower(), apikey, time_args)
             filename = "{0}.pdf".format(dest['titles'][dashboard])
 
             print("Downloading: ", filename)

--- a/scripts/grafana_pdf.py
+++ b/scripts/grafana_pdf.py
@@ -50,9 +50,9 @@ def parse_opts():
     parser.add_argument("-t", "--time", action="store", default=None,
                         help="Relative time to now, supported format is like: 2h, 4h. If not set, assume 3h by default.")
     parser.add_argument("--time-from", action="store", default=None,
-                        help="Start timestamp of time range, format: '%Y-%m-%d %H:%M:%S'.")
+                        help="Start timestamp of time range, format: '%%Y-%%m-%%d %%H:%%M:%%S'.")
     parser.add_argument("--time-to", action="store", default=None,
-                        help="End timestamp of time range, format: '%Y-%m-%d %H:%M:%S'.")
+                        help="End timestamp of time range, format: '%%Y-%%m-%%d %%H:%%M:%%S'.")
     return parser.parse_args()
 
 

--- a/scripts/grafana_pdf.py
+++ b/scripts/grafana_pdf.py
@@ -51,6 +51,22 @@ def parse_opts():
                         help="End timestamp of time range, format: '%Y-%m-%d %H:%M:%S'.")
     return parser.parse_args()
 
+def parse_timestamp(time_string):
+    format_guess = [
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%d %H:%M",
+        "%Y-%m-%d %H",
+        "%H:%M:%S",
+        "%H:%M",
+        "%H"
+    ]
+    for time_format in format_guess:
+        try:
+            return time.mktime(time.strptime(time_string, time_format))
+        except ValueError:
+            pass
+    raise ValueError("time data '%s' does not match any supported format." % time_string)
+
 if __name__ == '__main__':
     args = parse_opts()
     if not os.path.isdir(download_dir):
@@ -59,10 +75,10 @@ if __name__ == '__main__':
     if args.time:
         time_args = "&from=now-{0}&to=now".format(args.time)
     elif args.time_from:
-        start_time = int(time.mktime(time.strptime(args.time_from, "%Y-%m-%d %H:%M:%S")))
+        start_time = int(parse_timestamp(args.time_from))
         end_time = "now"
         if args.time_to:
-            end_time = int(time.mktime(time.strptime(args.time_to, "%Y-%m-%d %H:%M:%S")))
+            end_time = int(parse_timestamp(args.time_to))
         time_args = "&from={0}&to={1}".format(start_time, end_time)
     else:
         time_args = "&from=now-3h&to=now"


### PR DESCRIPTION
## Add time range support for Grafana screenshot utility.
There are 3 arguments that can be used:

 - `-t`/`--time`: A relative time range, collect the data from latest period, e.g: `-t 2h`, `--time 5h`
 - `--time-from`: The start time when specifying an absolute time period, e.g: `--time-from "2018-06-27 01:00:00"`, `--time-from "17:00"`, `--time-from "6-27"`
 - `--time-to`: The end time when specifying an absolute time period, in the same format as `--time-from`

It's possible to mix formats of `--time-from` and `--time-to`, if no argument specified, a default time period of latest 3 hours is used.

## Other changes

 - Support both Python 2 & 3
 - Add simple exception handling when querying Grafana APIs
 - Format code with `autopep8`