### PR TITLE
config: disable local latches for txn in tidb

### DIFF
--- a/conf/tidb.yml
+++ b/conf/tidb.yml
@@ -213,8 +213,8 @@ tikv_client:
 txn_local_latches:
   # Enable local latches for transactions. Enable it when
   # there are lots of conflicts between transactions.
-  # enabled: true
-  # capacity: 1024000
+  # enabled: false
+  # capacity: 10240000
 
 binlog:
   # WriteTimeout specifies how long it will wait for writing binlog to pump.

--- a/roles/tidb/vars/default.yml
+++ b/roles/tidb/vars/default.yml
@@ -222,8 +222,8 @@ tikv_client:
 txn_local_latches:
   # Enable local latches for transactions. Enable it when
   # there are lots of conflicts between transactions.
-  enabled: true
-  capacity: 1024000
+  enabled: false
+  capacity: 10240000
 
 binlog:
   # Socket file to write binlog.


### PR DESCRIPTION
Since enabling local latches for the transaction may cause fake conflicts in some situations, we'd like to disable it in default config.
@coocood @LinuxGit PTAL

The related PR: https://github.com/pingcap/tidb-ansible/pull/433