### PR TITLE
Collect config files with Insight

### DIFF
--- a/roles/collect_diagnosis/tasks/main.yml
+++ b/roles/collect_diagnosis/tasks/main.yml
@@ -4,5 +4,5 @@
   unarchive: >
     mode=0755
     dest={{ deploy_dir }}/scripts/
-    src={{ downloads_dir }}/tidb-insight-v0.2.1-7-gb53a69c.tar.gz
+    src={{ downloads_dir }}/tidb-insight-v0.2.1.1.tar.gz
 

--- a/roles/collect_diagnosis/tasks/main.yml
+++ b/roles/collect_diagnosis/tasks/main.yml
@@ -4,5 +4,5 @@
   unarchive: >
     mode=0755
     dest={{ deploy_dir }}/scripts/
-    src={{ downloads_dir }}/tidb-insight-v0.2.1-1-gc066a0e.tar.gz
+    src={{ downloads_dir }}/tidb-insight-v0.2.1-7-gb53a69c.tar.gz
 

--- a/roles/collector_pd/tasks/collect_config.yml
+++ b/roles/collector_pd/tasks/collect_config.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: check pd config directory
-  stat: path={{ pd_conf_dir | default(deploy_dir'/conf') }} get_md5=false get_checksum=false
+  stat: path={{ pd_conf_dir | default(deploy_dir, '/conf') }} get_md5=false get_checksum=false
   register: conf_dir_st
 
 - fail:
-    msg: "{{ pd_conf_dir | default(deploy_dir'/conf') }} must exist and is a directory"
+    msg: "{{ pd_conf_dir | default(deploy_dir, '/conf') }} must exist and is a directory"
   when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
 
 - name: collect pd config
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ pd_conf_dir | default(deploy_dir'/conf') }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ pd_conf_dir | default(deploy_dir, '/conf') }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_pd/tasks/collect_config.yml
+++ b/roles/collector_pd/tasks/collect_config.yml
@@ -2,7 +2,7 @@
 - name: check pd config path
   set_fact:
     pd_conf_dir: "{{ deploy_dir }}/conf"
-  when: pd_confi_dir is undefined
+  when: pd_conf_dir is undefined
 
 - name: check pd config directory
   stat: path={{ pd_conf_dir }} get_md5=false get_checksum=false
@@ -13,4 +13,4 @@
   when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
 
 - name: collect pd config
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --config-file --config-dir={{ pd_conf_dir }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --config-file --config-dir={{ pd_conf_dir }} --config-prefix=pd --output={{ pd_log_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_pd/tasks/collect_config.yml
+++ b/roles/collector_pd/tasks/collect_config.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: check pd config directory
-  stat: path={{ pd_conf_dir | default({{ deploy_dir }}/conf) }} get_md5=false get_checksum=false
+  stat: path={{ pd_conf_dir | default(deploy_dir'/conf') }} get_md5=false get_checksum=false
   register: conf_dir_st
 
 - fail:
-    msg: "{{ pd_conf_dir | default({{ deploy_dir }}/conf) }} must exist and is a directory"
+    msg: "{{ pd_conf_dir | default(deploy_dir'/conf') }} must exist and is a directory"
   when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
 
 - name: collect pd config
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ pd_conf_dir | default({{ deploy_dir }}/conf) }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ pd_conf_dir | default(deploy_dir'/conf') }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_pd/tasks/collect_config.yml
+++ b/roles/collector_pd/tasks/collect_config.yml
@@ -1,12 +1,16 @@
 ---
+- name: check pd config path
+  set_fact:
+    pd_conf_dir: "{{ deploy_dir }}/conf"
+  when: pd_confi_dir is undefined
 
 - name: check pd config directory
-  stat: path={{ pd_conf_dir | default(deploy_dir, '/conf') }} get_md5=false get_checksum=false
+  stat: path={{ pd_conf_dir }} get_md5=false get_checksum=false
   register: conf_dir_st
 
 - fail:
-    msg: "{{ pd_conf_dir | default(deploy_dir, '/conf') }} must exist and is a directory"
+    msg: "{{ pd_conf_dir }} must exist and is a directory"
   when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
 
 - name: collect pd config
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ pd_conf_dir | default(deploy_dir, '/conf') }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ pd_conf_dir }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_pd/tasks/collect_config.yml
+++ b/roles/collector_pd/tasks/collect_config.yml
@@ -13,4 +13,4 @@
   when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
 
 - name: collect pd config
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ pd_conf_dir }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --config-file --config-dir={{ pd_conf_dir }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_pd/tasks/collect_config.yml
+++ b/roles/collector_pd/tasks/collect_config.yml
@@ -1,0 +1,12 @@
+---
+
+- name: check pd config directory
+  stat: path={{ pd_conf_dir }} get_md5=false get_checksum=false
+  register: conf_dir_st
+
+- fail:
+    msg: "{{ pd_conf_dir }} must exist and is a directory"
+  when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
+
+- name: collect pd config
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ pd_conf_dir }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_pd/tasks/collect_config.yml
+++ b/roles/collector_pd/tasks/collect_config.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: check pd config directory
-  stat: path={{ pd_conf_dir }} get_md5=false get_checksum=false
+  stat: path={{ pd_conf_dir | default({{ deploy_dir }}/conf) }} get_md5=false get_checksum=false
   register: conf_dir_st
 
 - fail:
-    msg: "{{ pd_conf_dir }} must exist and is a directory"
+    msg: "{{ pd_conf_dir | default({{ deploy_dir }}/conf) }} must exist and is a directory"
   when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
 
 - name: collect pd config
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ pd_conf_dir }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ pd_conf_dir | default({{ deploy_dir }}/conf) }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_pd/tasks/collect_log.yml
+++ b/roles/collector_pd/tasks/collect_log.yml
@@ -9,23 +9,4 @@
   when: log_dir_st.stat.isdir is not defined or log_dir_st.stat.isdir == False
 
 - name: collect pd log
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --log-dir={{ pd_log_dir }} --log-prefix=pd --log-retention={{ collect_log_recent_hours | default('2') }} --output={{ pd_log_dir }} --alias={{ inventory_hostname }} --compress"
-
-- name: fetch pd log tarball with bandwidth limit
-  delegate_to: localhost
-  shell: "scp -P {{ ansible_port|default(22) }} -l {{ collect_bandwidth_limit|default('10000') }} -o StrictHostKeyChecking=no {{ service_host }}:{{ pd_log_dir }}/{{ inventory_hostname }}.tar.gz {{ fetch_tmp_dir }}/{{ service_host }}/pd_{{ inventory_hostname }}.tar.gz"
-  when: enable_bandwidth_limit|default(true)
-
-- name: fetch pd log tarball without bandwidth limit
-  fetch:
-    src: "{{ pd_log_dir }}/{{ inventory_hostname }}.tar.gz"
-    dest: "{{ fetch_tmp_dir }}/{{ service_host }}/pd_{{ inventory_hostname }}.tar.gz"
-    flat: yes
-  when: not enable_bandwidth_limit|default(true)
-
-- name: remove pd temporary log tarball
-  file:
-    path: "{{ pd_log_dir }}/{{ item }}"
-    state: absent
-  with_items:
-    - "{{ inventory_hostname }}.tar.gz"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --log-dir={{ pd_log_dir }} --log-prefix=pd --log-retention={{ collect_log_recent_hours | default('2') }} --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_pd/tasks/collect_log.yml
+++ b/roles/collector_pd/tasks/collect_log.yml
@@ -9,4 +9,4 @@
   when: log_dir_st.stat.isdir is not defined or log_dir_st.stat.isdir == False
 
 - name: collect pd log
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --log-dir={{ pd_log_dir }} --log-prefix=pd --log-retention={{ collect_log_recent_hours | default('2') }} --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --log-dir={{ pd_log_dir }} --log-prefix=pd --log-retention={{ collect_log_recent_hours | default('2') }} --output={{ pd_log_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_pd/tasks/main.yml
+++ b/roles/collector_pd/tasks/main.yml
@@ -11,6 +11,7 @@
     - "{{ fetch_tmp_dir }}/{{ service_host }}"
 
 - include_tasks: collect_log.yml
+- include_tasks: collect_config.yml
 
 - name: compress collected data
   shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_pd/tasks/main.yml
+++ b/roles/collector_pd/tasks/main.yml
@@ -11,3 +11,25 @@
     - "{{ fetch_tmp_dir }}/{{ service_host }}"
 
 - include_tasks: collect_log.yml
+
+- name: compress collected data
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+
+- name: fetch pd diagnosis tarball with bandwidth limit
+  delegate_to: localhost
+  shell: "scp -P {{ ansible_port|default(22) }} -l {{ collect_bandwidth_limit|default('10000') }} -o StrictHostKeyChecking=no {{ service_host }}:{{ deploy_dir }}/{{ inventory_hostname }}.tar.gz {{ fetch_tmp_dir }}/{{ service_host }}/pd_{{ inventory_hostname }}.tar.gz"
+  when: enable_bandwidth_limit|default(true)
+
+- name: fetch pd diagnosis tarball without bandwidth limit
+  fetch:
+    src: "{{ deploy_dir }}/{{ inventory_hostname }}.tar.gz"
+    dest: "{{ fetch_tmp_dir }}/{{ service_host }}/pd_{{ inventory_hostname }}.tar.gz"
+    flat: yes
+  when: not enable_bandwidth_limit|default(true)
+
+- name: remove pd temporary diagnosis tarball
+  file:
+    path: "{{ deploy_dir }}/{{ item }}"
+    state: absent
+  with_items:
+    - "{{ inventory_hostname }}.tar.gz"

--- a/roles/collector_pd/tasks/main.yml
+++ b/roles/collector_pd/tasks/main.yml
@@ -14,7 +14,7 @@
 - include_tasks: collect_config.yml
 
 - name: compress collected data
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ pd_log_dir }} --alias={{ inventory_hostname }}"
 
 - name: fetch pd diagnosis tarball with bandwidth limit
   delegate_to: localhost
@@ -23,14 +23,14 @@
 
 - name: fetch pd diagnosis tarball without bandwidth limit
   fetch:
-    src: "{{ deploy_dir }}/{{ inventory_hostname }}.tar.gz"
+    src: "{{ pd_log_dir }}/{{ inventory_hostname }}.tar.gz"
     dest: "{{ fetch_tmp_dir }}/{{ service_host }}/pd_{{ inventory_hostname }}.tar.gz"
     flat: yes
   when: not enable_bandwidth_limit|default(true)
 
 - name: remove pd temporary diagnosis tarball
   file:
-    path: "{{ deploy_dir }}/{{ item }}"
+    path: "{{ pd_log_dir }}/{{ item }}"
     state: absent
   with_items:
     - "{{ inventory_hostname }}.tar.gz"

--- a/roles/collector_pd/tasks/main.yml
+++ b/roles/collector_pd/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: fetch pd diagnosis tarball with bandwidth limit
   delegate_to: localhost
-  shell: "scp -P {{ ansible_port|default(22) }} -l {{ collect_bandwidth_limit|default('10000') }} -o StrictHostKeyChecking=no {{ service_host }}:{{ deploy_dir }}/{{ inventory_hostname }}.tar.gz {{ fetch_tmp_dir }}/{{ service_host }}/pd_{{ inventory_hostname }}.tar.gz"
+  shell: "scp -P {{ ansible_port|default(22) }} -l {{ collect_bandwidth_limit|default('10000') }} -o StrictHostKeyChecking=no {{ service_host }}:{{ pd_log_dir }}/{{ inventory_hostname }}.tar.gz {{ fetch_tmp_dir }}/{{ service_host }}/pd_{{ inventory_hostname }}.tar.gz"
   when: enable_bandwidth_limit|default(true)
 
 - name: fetch pd diagnosis tarball without bandwidth limit

--- a/roles/collector_tidb/tasks/collect_config.yml
+++ b/roles/collector_tidb/tasks/collect_config.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: check pd config directory
-  stat: path={{ tidb_conf_dir }} get_md5=false get_checksum=false
+  stat: path={{ tidb_conf_dir | default({{ deploy_dir }}/conf) }} get_md5=false get_checksum=false
   register: conf_dir_st
 
 - fail:
-    msg: "{{ tidb_conf_dir }} must exist and is a directory"
+    msg: "{{ tidb_conf_dir | default({{ deploy_dir }}/conf) }} must exist and is a directory"
   when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
 
 - name: collect tidb config
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ tidb_conf_dir }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ tidb_conf_dir | default({{ deploy_dir }}/conf) }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_tidb/tasks/collect_config.yml
+++ b/roles/collector_tidb/tasks/collect_config.yml
@@ -14,4 +14,4 @@
   when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
 
 - name: collect tidb config
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ tidb_conf_dir }} --config-prefix=tidb --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --config-file --config-dir={{ tidb_conf_dir }} --config-prefix=tidb --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_tidb/tasks/collect_config.yml
+++ b/roles/collector_tidb/tasks/collect_config.yml
@@ -3,7 +3,7 @@
 - name: check tidb config path
   set_fact:
     tidb_conf_dir: "{{ deploy_dir }}/conf"
-  when: tidb_confi_dir is undefined
+  when: tidb_conf_dir is undefined
 
 - name: check tidb config directory
   stat: path={{ tidb_conf_dir }} get_md5=false get_checksum=false
@@ -14,4 +14,4 @@
   when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
 
 - name: collect tidb config
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --config-file --config-dir={{ tidb_conf_dir }} --config-prefix=tidb --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --config-file --config-dir={{ tidb_conf_dir }} --config-prefix=tidb --output={{ tidb_log_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_tidb/tasks/collect_config.yml
+++ b/roles/collector_tidb/tasks/collect_config.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: check pd config directory
-  stat: path={{ tidb_conf_dir | default(deploy_dir'/conf') }} get_md5=false get_checksum=false
+  stat: path={{ tidb_conf_dir | default(deploy_dir, '/conf') }} get_md5=false get_checksum=false
   register: conf_dir_st
 
 - fail:
-    msg: "{{ tidb_conf_dir | default(deploy_dir'/conf') }} must exist and is a directory"
+    msg: "{{ tidb_conf_dir | default(deploy_dir, '/conf') }} must exist and is a directory"
   when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
 
 - name: collect tidb config
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ tidb_conf_dir | default(deploy_dir'/conf') }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ tidb_conf_dir | default(deploy_dir, '/conf') }} --config-prefix=tidb --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_tidb/tasks/collect_config.yml
+++ b/roles/collector_tidb/tasks/collect_config.yml
@@ -1,12 +1,17 @@
 ---
 
-- name: check pd config directory
-  stat: path={{ tidb_conf_dir | default(deploy_dir, '/conf') }} get_md5=false get_checksum=false
+- name: check tidb config path
+  set_fact:
+    tidb_conf_dir: "{{ deploy_dir }}/conf"
+  when: tidb_confi_dir is undefined
+
+- name: check tidb config directory
+  stat: path={{ tidb_conf_dir }} get_md5=false get_checksum=false
   register: conf_dir_st
 
 - fail:
-    msg: "{{ tidb_conf_dir | default(deploy_dir, '/conf') }} must exist and is a directory"
+    msg: "{{ tidb_conf_dir }} must exist and is a directory"
   when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
 
 - name: collect tidb config
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ tidb_conf_dir | default(deploy_dir, '/conf') }} --config-prefix=tidb --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ tidb_conf_dir }} --config-prefix=tidb --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_tidb/tasks/collect_config.yml
+++ b/roles/collector_tidb/tasks/collect_config.yml
@@ -1,0 +1,12 @@
+---
+
+- name: check pd config directory
+  stat: path={{ tidb_conf_dir }} get_md5=false get_checksum=false
+  register: conf_dir_st
+
+- fail:
+    msg: "{{ tidb_conf_dir }} must exist and is a directory"
+  when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
+
+- name: collect tidb config
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ tidb_conf_dir }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_tidb/tasks/collect_config.yml
+++ b/roles/collector_tidb/tasks/collect_config.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: check pd config directory
-  stat: path={{ tidb_conf_dir | default({{ deploy_dir }}/conf) }} get_md5=false get_checksum=false
+  stat: path={{ tidb_conf_dir | default(deploy_dir'/conf') }} get_md5=false get_checksum=false
   register: conf_dir_st
 
 - fail:
-    msg: "{{ tidb_conf_dir | default({{ deploy_dir }}/conf) }} must exist and is a directory"
+    msg: "{{ tidb_conf_dir | default(deploy_dir'/conf') }} must exist and is a directory"
   when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
 
 - name: collect tidb config
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ tidb_conf_dir | default({{ deploy_dir }}/conf) }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ tidb_conf_dir | default(deploy_dir'/conf') }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_tidb/tasks/collect_log.yml
+++ b/roles/collector_tidb/tasks/collect_log.yml
@@ -9,4 +9,4 @@
   when: log_dir_st.stat.isdir is not defined or log_dir_st.stat.isdir == False
 
 - name: collect tidb log
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --log-dir={{ tidb_log_dir }} --log-prefix=tidb --log-retention={{ collect_log_recent_hours | default('2') }} --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --log-dir={{ tidb_log_dir }} --log-prefix=tidb --log-retention={{ collect_log_recent_hours | default('2') }} --output={{ tidb_log_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_tidb/tasks/collect_log.yml
+++ b/roles/collector_tidb/tasks/collect_log.yml
@@ -9,23 +9,4 @@
   when: log_dir_st.stat.isdir is not defined or log_dir_st.stat.isdir == False
 
 - name: collect tidb log
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --log-dir={{ tidb_log_dir }} --log-prefix=tidb --log-retention={{ collect_log_recent_hours | default('2') }} --output={{ tidb_log_dir }} --alias={{ inventory_hostname }} --compress"
-
-- name: fetch tidb log tarball with bandwidth limit
-  delegate_to: localhost
-  shell: "scp -P {{ ansible_port|default(22) }} -l {{ collect_bandwidth_limit|default('10000') }} -o StrictHostKeyChecking=no {{ service_host }}:{{ tidb_log_dir }}/{{ inventory_hostname }}.tar.gz {{ fetch_tmp_dir }}/{{ service_host }}/tidb_{{ inventory_hostname }}.tar.gz"
-  when: enable_bandwidth_limit|default(true)
-
-- name: fetch tidb log tarball without bandwidth limit
-  fetch:
-    src: "{{ tidb_log_dir }}/{{ inventory_hostname }}.tar.gz"
-    dest: "{{ fetch_tmp_dir }}/{{ service_host }}/tidb_{{ inventory_hostname }}.tar.gz"
-    flat: yes
-  when: not enable_bandwidth_limit|default(true)
-
-- name: remove tidb temporary log tarball
-  file:
-    path: "{{ tidb_log_dir }}/{{ item }}"
-    state: absent
-  with_items:
-    - "{{ inventory_hostname }}.tar.gz"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --log-dir={{ tidb_log_dir }} --log-prefix=tidb --log-retention={{ collect_log_recent_hours | default('2') }} --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_tidb/tasks/main.yml
+++ b/roles/collector_tidb/tasks/main.yml
@@ -11,6 +11,7 @@
     - "{{ fetch_tmp_dir }}/{{ service_host }}"
 
 - include_tasks: collect_log.yml
+- include_tasks: collect_config.yml
 
 - name: compress collected data
   shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_tidb/tasks/main.yml
+++ b/roles/collector_tidb/tasks/main.yml
@@ -14,7 +14,7 @@
 - include_tasks: collect_config.yml
 
 - name: compress collected data
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ tidb_log_dir }} --alias={{ inventory_hostname }}"
 
 - name: fetch tidb diagnosis tarball with bandwidth limit
   delegate_to: localhost
@@ -23,14 +23,14 @@
 
 - name: fetch tidb diagnosis tarball without bandwidth limit
   fetch:
-    src: "{{ deploy_dir }}/{{ inventory_hostname }}.tar.gz"
+    src: "{{ tidb_log_dir }}/{{ inventory_hostname }}.tar.gz"
     dest: "{{ fetch_tmp_dir }}/{{ service_host }}/tidb_{{ inventory_hostname }}.tar.gz"
     flat: yes
   when: not enable_bandwidth_limit|default(true)
 
 - name: remove tidb temporary diagnosis tarball
   file:
-    path: "{{ deploy_dir }}/{{ item }}"
+    path: "{{ tidb_log_dir }}/{{ item }}"
     state: absent
   with_items:
     - "{{ inventory_hostname }}.tar.gz"

--- a/roles/collector_tidb/tasks/main.yml
+++ b/roles/collector_tidb/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: fetch tidb diagnosis tarball with bandwidth limit
   delegate_to: localhost
-  shell: "scp -P {{ ansible_port|default(22) }} -l {{ collect_bandwidth_limit|default('10000') }} -o StrictHostKeyChecking=no {{ service_host }}:{{ deploy_dir }}/{{ inventory_hostname }}.tar.gz {{ fetch_tmp_dir }}/{{ service_host }}/tidb_{{ inventory_hostname }}.tar.gz"
+  shell: "scp -P {{ ansible_port|default(22) }} -l {{ collect_bandwidth_limit|default('10000') }} -o StrictHostKeyChecking=no {{ service_host }}:{{ tidb_log_dir }}/{{ inventory_hostname }}.tar.gz {{ fetch_tmp_dir }}/{{ service_host }}/tidb_{{ inventory_hostname }}.tar.gz"
   when: enable_bandwidth_limit|default(true)
 
 - name: fetch tidb diagnosis tarball without bandwidth limit

--- a/roles/collector_tidb/tasks/main.yml
+++ b/roles/collector_tidb/tasks/main.yml
@@ -11,3 +11,25 @@
     - "{{ fetch_tmp_dir }}/{{ service_host }}"
 
 - include_tasks: collect_log.yml
+
+- name: compress collected data
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+
+- name: fetch tidb diagnosis tarball with bandwidth limit
+  delegate_to: localhost
+  shell: "scp -P {{ ansible_port|default(22) }} -l {{ collect_bandwidth_limit|default('10000') }} -o StrictHostKeyChecking=no {{ service_host }}:{{ deploy_dir }}/{{ inventory_hostname }}.tar.gz {{ fetch_tmp_dir }}/{{ service_host }}/tidb_{{ inventory_hostname }}.tar.gz"
+  when: enable_bandwidth_limit|default(true)
+
+- name: fetch tidb diagnosis tarball without bandwidth limit
+  fetch:
+    src: "{{ deploy_dir }}/{{ inventory_hostname }}.tar.gz"
+    dest: "{{ fetch_tmp_dir }}/{{ service_host }}/tidb_{{ inventory_hostname }}.tar.gz"
+    flat: yes
+  when: not enable_bandwidth_limit|default(true)
+
+- name: remove tidb temporary diagnosis tarball
+  file:
+    path: "{{ deploy_dir }}/{{ item }}"
+    state: absent
+  with_items:
+    - "{{ inventory_hostname }}.tar.gz"

--- a/roles/collector_tikv/tasks/collect_config.yml
+++ b/roles/collector_tikv/tasks/collect_config.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: check pd config directory
-  stat: path={{ tikv_conf_dir }} get_md5=false get_checksum=false
+  stat: path={{ tikv_conf_dir | default({{ deploy_dir }}/conf) }} get_md5=false get_checksum=false
   register: conf_dir_st
 
 - fail:
-    msg: "{{ tikv_conf_dir }} must exist and is a directory"
+    msg: "{{ tikv_conf_dir | default({{ deploy_dir }}/conf) }} must exist and is a directory"
   when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
 
 - name: collect tikv config
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ tikv_conf_dir }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ tikv_conf_dir | default({{ deploy_dir }}/conf) }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_tikv/tasks/collect_config.yml
+++ b/roles/collector_tikv/tasks/collect_config.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: check pd config directory
-  stat: path={{ tikv_conf_dir | default(deploy_dir'/conf') }} get_md5=false get_checksum=false
+  stat: path={{ tikv_conf_dir | default(deploy_dir, '/conf') }} get_md5=false get_checksum=false
   register: conf_dir_st
 
 - fail:
-    msg: "{{ tikv_conf_dir | default(deploy_dir'/conf') }} must exist and is a directory"
+    msg: "{{ tikv_conf_dir | default(deploy_dir, '/conf') }} must exist and is a directory"
   when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
 
 - name: collect tikv config
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ tikv_conf_dir | default(deploy_dir'/conf') }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ tikv_conf_dir | default(deploy_dir, '/conf') }} --config-prefix=tikv --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_tikv/tasks/collect_config.yml
+++ b/roles/collector_tikv/tasks/collect_config.yml
@@ -3,7 +3,7 @@
 - name: check tikv config path
   set_fact:
     tikv_conf_dir: "{{ deploy_dir }}/conf"
-  when: tikv_confi_dir is undefined
+  when: tikv_conf_dir is undefined
 
 - name: check tikv config directory
   stat: path={{ tikv_conf_dir }} get_md5=false get_checksum=false
@@ -14,4 +14,4 @@
   when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
 
 - name: collect tikv config
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --config-file --config-dir={{ tikv_conf_dir }} --config-prefix=tikv --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --config-file --config-dir={{ tikv_conf_dir }} --config-prefix=tikv --output={{ tikv_conf_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_tikv/tasks/collect_config.yml
+++ b/roles/collector_tikv/tasks/collect_config.yml
@@ -1,0 +1,12 @@
+---
+
+- name: check pd config directory
+  stat: path={{ tikv_conf_dir }} get_md5=false get_checksum=false
+  register: conf_dir_st
+
+- fail:
+    msg: "{{ tikv_conf_dir }} must exist and is a directory"
+  when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
+
+- name: collect tikv config
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ tikv_conf_dir }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_tikv/tasks/collect_config.yml
+++ b/roles/collector_tikv/tasks/collect_config.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: check pd config directory
-  stat: path={{ tikv_conf_dir | default({{ deploy_dir }}/conf) }} get_md5=false get_checksum=false
+  stat: path={{ tikv_conf_dir | default(deploy_dir'/conf') }} get_md5=false get_checksum=false
   register: conf_dir_st
 
 - fail:
-    msg: "{{ tikv_conf_dir | default({{ deploy_dir }}/conf) }} must exist and is a directory"
+    msg: "{{ tikv_conf_dir | default(deploy_dir'/conf') }} must exist and is a directory"
   when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
 
 - name: collect tikv config
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ tikv_conf_dir | default({{ deploy_dir }}/conf) }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ tikv_conf_dir | default(deploy_dir'/conf') }} --config-prefix=pd --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_tikv/tasks/collect_config.yml
+++ b/roles/collector_tikv/tasks/collect_config.yml
@@ -14,4 +14,4 @@
   when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
 
 - name: collect tikv config
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --config-file --config-dir={{ tikv_conf_dir }} --config-prefix=tikv --output={{ tikv_conf_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --config-file --config-dir={{ tikv_conf_dir }} --config-prefix=tikv --output={{ tikv_log_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_tikv/tasks/collect_config.yml
+++ b/roles/collector_tikv/tasks/collect_config.yml
@@ -1,12 +1,17 @@
 ---
 
-- name: check pd config directory
-  stat: path={{ tikv_conf_dir | default(deploy_dir, '/conf') }} get_md5=false get_checksum=false
+- name: check tikv config path
+  set_fact:
+    tikv_conf_dir: "{{ deploy_dir }}/conf"
+  when: tikv_confi_dir is undefined
+
+- name: check tikv config directory
+  stat: path={{ tikv_conf_dir }} get_md5=false get_checksum=false
   register: conf_dir_st
 
 - fail:
-    msg: "{{ tikv_conf_dir | default(deploy_dir, '/conf') }} must exist and is a directory"
+    msg: "{{ tikv_conf_dir }} must exist and is a directory"
   when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
 
 - name: collect tikv config
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --config-dir={{ tikv_conf_dir | default(deploy_dir, '/conf') }} --config-prefix=tikv --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --config-file --config-dir={{ tikv_conf_dir }} --config-prefix=tikv --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_tikv/tasks/collect_log.yml
+++ b/roles/collector_tikv/tasks/collect_log.yml
@@ -9,4 +9,4 @@
   when: log_dir_st.stat.isdir is not defined or log_dir_st.stat.isdir == False
 
 - name: collect tikv log
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --log-dir={{ tikv_log_dir }} --log-prefix=tikv --log-retention={{ collect_log_recent_hours | default('2') }} --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --log-dir={{ tikv_log_dir }} --log-prefix=tikv --log-retention={{ collect_log_recent_hours | default('2') }} --output={{ tikv_log_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_tikv/tasks/collect_log.yml
+++ b/roles/collector_tikv/tasks/collect_log.yml
@@ -9,23 +9,4 @@
   when: log_dir_st.stat.isdir is not defined or log_dir_st.stat.isdir == False
 
 - name: collect tikv log
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --log-dir={{ tikv_log_dir }} --log-prefix=tikv --log-retention={{ collect_log_recent_hours | default('2') }} --output={{ tikv_log_dir }} --alias={{ inventory_hostname }} --compress"
-
-- name: fetch tikv log tarball with bandwidth limit
-  delegate_to: localhost
-  shell: "scp -P {{ ansible_port|default(22) }} -l {{ collect_bandwidth_limit|default('10000') }} -o StrictHostKeyChecking=no {{ service_host }}:{{ tikv_log_dir }}/{{ inventory_hostname }}.tar.gz {{ fetch_tmp_dir }}/{{ service_host }}/tikv_{{ inventory_hostname }}.tar.gz"
-  when: enable_bandwidth_limit|default(true)
-
-- name: fetch tikv log tarball without bandwidth limit
-  fetch:
-    src: "{{ tikv_log_dir }}/{{ inventory_hostname }}.tar.gz"
-    dest: "{{ fetch_tmp_dir }}/{{ service_host }}/tikv_{{ inventory_hostname }}.tar.gz"
-    flat: yes
-  when: not enable_bandwidth_limit|default(true)
-
-- name: remove tikv temporary log tarball
-  file:
-    path: "{{ tikv_log_dir }}/{{ item }}"
-    state: absent
-  with_items:
-    - "{{ inventory_hostname }}.tar.gz"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --log-dir={{ tikv_log_dir }} --log-prefix=tikv --log-retention={{ collect_log_recent_hours | default('2') }} --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_tikv/tasks/main.yml
+++ b/roles/collector_tikv/tasks/main.yml
@@ -11,6 +11,7 @@
     - "{{ fetch_tmp_dir }}/{{ service_host }}"
 
 - include_tasks: collect_log.yml
+- include_tasks: collect_config.yml
 
 - name: compress collected data
   shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ deploy_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_tikv/tasks/main.yml
+++ b/roles/collector_tikv/tasks/main.yml
@@ -14,7 +14,7 @@
 - include_tasks: collect_config.yml
 
 - name: compress collected data
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ tikv_log_dir }} --alias={{ inventory_hostname }}"
 
 - name: fetch tikv diagnosis tarball with bandwidth limit
   delegate_to: localhost
@@ -23,14 +23,14 @@
 
 - name: fetch tikv diagnosis tarball without bandwidth limit
   fetch:
-    src: "{{ deploy_dir }}/{{ inventory_hostname }}.tar.gz"
+    src: "{{ tikv_log_dir }}/{{ inventory_hostname }}.tar.gz"
     dest: "{{ fetch_tmp_dir }}/{{ service_host }}/tikv_{{ inventory_hostname }}.tar.gz"
     flat: yes
   when: not enable_bandwidth_limit|default(true)
 
 - name: remove tikv temporary diagnosis tarball
   file:
-    path: "{{ deploy_dir }}/{{ item }}"
+    path: "{{ tikv_log_dir }}/{{ item }}"
     state: absent
   with_items:
     - "{{ inventory_hostname }}.tar.gz"

--- a/roles/collector_tikv/tasks/main.yml
+++ b/roles/collector_tikv/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: fetch tikv diagnosis tarball with bandwidth limit
   delegate_to: localhost
-  shell: "scp -P {{ ansible_port|default(22) }} -l {{ collect_bandwidth_limit|default('10000') }} -o StrictHostKeyChecking=no {{ service_host }}:{{ deploy_dir }}/{{ inventory_hostname }}.tar.gz {{ fetch_tmp_dir }}/{{ service_host }}/tikv_{{ inventory_hostname }}.tar.gz"
+  shell: "scp -P {{ ansible_port|default(22) }} -l {{ collect_bandwidth_limit|default('10000') }} -o StrictHostKeyChecking=no {{ service_host }}:{{ tikv_log_dir }}/{{ inventory_hostname }}.tar.gz {{ fetch_tmp_dir }}/{{ service_host }}/tikv_{{ inventory_hostname }}.tar.gz"
   when: enable_bandwidth_limit|default(true)
 
 - name: fetch tikv diagnosis tarball without bandwidth limit

--- a/roles/collector_tikv/tasks/main.yml
+++ b/roles/collector_tikv/tasks/main.yml
@@ -11,3 +11,25 @@
     - "{{ fetch_tmp_dir }}/{{ service_host }}"
 
 - include_tasks: collect_log.yml
+
+- name: compress collected data
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ deploy_dir }} --alias={{ inventory_hostname }}"
+
+- name: fetch tikv diagnosis tarball with bandwidth limit
+  delegate_to: localhost
+  shell: "scp -P {{ ansible_port|default(22) }} -l {{ collect_bandwidth_limit|default('10000') }} -o StrictHostKeyChecking=no {{ service_host }}:{{ deploy_dir }}/{{ inventory_hostname }}.tar.gz {{ fetch_tmp_dir }}/{{ service_host }}/tikv_{{ inventory_hostname }}.tar.gz"
+  when: enable_bandwidth_limit|default(true)
+
+- name: fetch tikv diagnosis tarball without bandwidth limit
+  fetch:
+    src: "{{ deploy_dir }}/{{ inventory_hostname }}.tar.gz"
+    dest: "{{ fetch_tmp_dir }}/{{ service_host }}/tikv_{{ inventory_hostname }}.tar.gz"
+    flat: yes
+  when: not enable_bandwidth_limit|default(true)
+
+- name: remove tikv temporary diagnosis tarball
+  file:
+    path: "{{ deploy_dir }}/{{ item }}"
+    state: absent
+  with_items:
+    - "{{ inventory_hostname }}.tar.gz"

--- a/roles/local/templates/common_packages.yml.j2
+++ b/roles/local/templates/common_packages.yml.j2
@@ -33,5 +33,5 @@ common_packages:
 
 diagnosis_packages:
   - name: tidb-insight
-    version: v0.2.1-7-gb53a69c
-    url: https://download.pingcap.org/tidb-insight-v0.2.1-7-gb53a69c.tar.gz
+    version: v0.2.1.1
+    url: https://download.pingcap.org/tidb-insight-v0.2.1.1.tar.gz

--- a/roles/local/templates/common_packages.yml.j2
+++ b/roles/local/templates/common_packages.yml.j2
@@ -33,5 +33,5 @@ common_packages:
 
 diagnosis_packages:
   - name: tidb-insight
-    version: v0.2.1-1-gc066a0e
-    url: https://download.pingcap.org/tidb-insight-v0.2.1-1-gc066a0e.tar.gz
+    version: v0.2.1-7-gb53a69c
+    url: https://download.pingcap.org/tidb-insight-v0.2.1-7-gb53a69c.tar.gz


### PR DESCRIPTION
Several changes are made in this PR:

 - Do not compress output files until all collecting tasks are done
 - Compress and retrieve tarball only once per role
 - Add tasks to collect config files of TiDB/TiKV/PD instances

This PR, in combination with #453, setup the basic structure of `tidb-insight` tasks, and future new tasks would (hopefully) be easier to be added.