### PR TITLE
Add collecting of basic system info & pd info

### DIFF
--- a/roles/collect_diagnosis/tasks/main.yml
+++ b/roles/collect_diagnosis/tasks/main.yml
@@ -4,5 +4,5 @@
   unarchive: >
     mode=0755
     dest={{ deploy_dir }}/scripts/
-    src={{ downloads_dir }}/tidb-insight-v0.2.1.1-2-g2924ad1.tar.gz
+    src={{ downloads_dir }}/tidb-insight.tar.gz
 

--- a/roles/collect_diagnosis/tasks/main.yml
+++ b/roles/collect_diagnosis/tasks/main.yml
@@ -4,5 +4,5 @@
   unarchive: >
     mode=0755
     dest={{ deploy_dir }}/scripts/
-    src={{ downloads_dir }}/tidb-insight-v0.2.1.1.tar.gz
+    src={{ downloads_dir }}/tidb-insight-v0.2.1.1-1-gfbfc8b6.tar.gz
 

--- a/roles/collect_diagnosis/tasks/main.yml
+++ b/roles/collect_diagnosis/tasks/main.yml
@@ -4,5 +4,5 @@
   unarchive: >
     mode=0755
     dest={{ deploy_dir }}/scripts/
-    src={{ downloads_dir }}/tidb-insight-v0.2.1.1-1-gfbfc8b6.tar.gz
+    src={{ downloads_dir }}/tidb-insight-v0.2.1.1-2-g2924ad1.tar.gz
 

--- a/roles/collector_pd/tasks/main.yml
+++ b/roles/collector_pd/tasks/main.yml
@@ -14,7 +14,7 @@
 - include_tasks: collect_config.yml
 
 - name: collect PD information
-  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} --pdctl --pd-host={{ inventory_hostname }} --pd-port={{ pd_client_port }}
+  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} --pdctl --pd-host={{ pd_host }} --pd-port={{ pd_client_port }}
 
 - name: collect basic system information
   shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }}/pd_{{ inventory_hostname }} --alias={{ inventory_hostname }} --collector

--- a/roles/collector_pd/tasks/main.yml
+++ b/roles/collector_pd/tasks/main.yml
@@ -14,7 +14,7 @@
 - include_tasks: collect_config.yml
 
 - name: collect PD information
-  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} --pdctl --pd-host={{ pd_host }} --pd-port={{ pd_client_port }}
+  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} --pdctl --pd-host={{ ansible_host }} --pd-port={{ pd_client_port }}
 
 - name: collect basic system information
   shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }}/pd_{{ inventory_hostname }} --alias={{ inventory_hostname }} --collector

--- a/roles/collector_pd/tasks/main.yml
+++ b/roles/collector_pd/tasks/main.yml
@@ -13,6 +13,9 @@
 - include_tasks: collect_log.yml
 - include_tasks: collect_config.yml
 
+- name: collect basic system information
+  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} --collector
+
 - name: compress collected data
   shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ pd_log_dir }} --alias={{ inventory_hostname }}"
 

--- a/roles/collector_pd/tasks/main.yml
+++ b/roles/collector_pd/tasks/main.yml
@@ -13,6 +13,9 @@
 - include_tasks: collect_log.yml
 - include_tasks: collect_config.yml
 
+- name: collect PD information
+  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} --pdctl
+
 - name: collect basic system information
   shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} --collector
 

--- a/roles/collector_pd/tasks/main.yml
+++ b/roles/collector_pd/tasks/main.yml
@@ -17,7 +17,7 @@
   shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} --pdctl --pd-host={{ ansible_host }} --pd-port={{ pd_client_port }}
 
 - name: collect basic system information
-  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }}/pd_{{ inventory_hostname }} --alias={{ inventory_hostname }} --collector
+  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} --collector
 
 - name: compress collected data
   shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ pd_log_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_pd/tasks/main.yml
+++ b/roles/collector_pd/tasks/main.yml
@@ -14,7 +14,7 @@
 - include_tasks: collect_config.yml
 
 - name: collect PD information
-  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} --pdctl --pd-host={{ my_ip }} --pd-port={{ pd_client_port }}
+  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} --pdctl --pd-host={{ hostvars[inventory_hostname].ansible_host | default(hostvars[inventory_hostname].inventory_hostname) }} --pd-port={{ pd_client_port }}
 
 - name: collect basic system information
   shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} --collector

--- a/roles/collector_pd/tasks/main.yml
+++ b/roles/collector_pd/tasks/main.yml
@@ -14,10 +14,10 @@
 - include_tasks: collect_config.yml
 
 - name: collect PD information
-  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} --pdctl --pd-host={{ hostvars[inventory_hostname].ansible_host | default(hostvars[inventory_hostname].inventory_hostname) }} --pd-port={{ pd_client_port }}
+  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} --pdctl --pd-host={{ inventory_hostname }} --pd-port={{ pd_client_port }}
 
 - name: collect basic system information
-  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} --collector
+  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }}/pd_{{ inventory_hostname }} --alias={{ inventory_hostname }} --collector
 
 - name: compress collected data
   shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ pd_log_dir }} --alias={{ inventory_hostname }}"

--- a/roles/collector_pd/tasks/main.yml
+++ b/roles/collector_pd/tasks/main.yml
@@ -14,7 +14,7 @@
 - include_tasks: collect_config.yml
 
 - name: collect PD information
-  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} --pdctl
+  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} --pdctl --pd-host={{ my_ip }} --pd-port={{ pd_client_port }}
 
 - name: collect basic system information
   shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} --collector

--- a/roles/collector_tidb/tasks/main.yml
+++ b/roles/collector_tidb/tasks/main.yml
@@ -13,6 +13,9 @@
 - include_tasks: collect_log.yml
 - include_tasks: collect_config.yml
 
+- name: collect basic system information
+  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ tidb_log_dir }} --alias={{ inventory_hostname }} --collector
+
 - name: compress collected data
   shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ tidb_log_dir }} --alias={{ inventory_hostname }}"
 

--- a/roles/collector_tikv/tasks/main.yml
+++ b/roles/collector_tikv/tasks/main.yml
@@ -13,6 +13,9 @@
 - include_tasks: collect_log.yml
 - include_tasks: collect_config.yml
 
+- name: collect basic system information
+  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ tikv_log_dir }} --alias={{ inventory_hostname }} --collector
+
 - name: compress collected data
   shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ tikv_log_dir }} --alias={{ inventory_hostname }}"
 

--- a/roles/local/tasks/main.yml
+++ b/roles/local/tasks/main.yml
@@ -171,6 +171,9 @@
     - svc
   when: process_supervision == 'supervise'
 
+- name: cp tidb-insight tarball
+  shell: mv {{ downloads_dir }}/tidb-insight-v*.tar.gz {{ downloads_dir }}/tidb-insight.tar.gz
+
 - name: clean up download dir
   shell: >
     cd "{{ downloads_dir }}" && find . -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} \;

--- a/roles/local/templates/common_packages.yml.j2
+++ b/roles/local/templates/common_packages.yml.j2
@@ -33,5 +33,5 @@ common_packages:
 
 diagnosis_packages:
   - name: tidb-insight
-    version: v0.2.1.1-2-g2924ad1
-    url: https://download.pingcap.org/tidb-insight-v0.2.1.1-2-g2924ad1.tar.gz
+    version: v0.2.1.1-4-gc03fa7b
+    url: https://download.pingcap.org/tidb-insight-v0.2.1.1-4-gc03fa7b.tar.gz

--- a/roles/local/templates/common_packages.yml.j2
+++ b/roles/local/templates/common_packages.yml.j2
@@ -33,5 +33,5 @@ common_packages:
 
 diagnosis_packages:
   - name: tidb-insight
-    version: v0.2.1.1-1-gfbfc8b6
-    url: https://download.pingcap.org/tidb-insight-v0.2.1.1-1-gfbfc8b6.tar.gz
+    version: v0.2.1.1-2-g2924ad1
+    url: https://download.pingcap.org/tidb-insight-v0.2.1.1-2-g2924ad1.tar.gz

--- a/roles/local/templates/common_packages.yml.j2
+++ b/roles/local/templates/common_packages.yml.j2
@@ -33,5 +33,5 @@ common_packages:
 
 diagnosis_packages:
   - name: tidb-insight
-    version: v0.2.1.1
-    url: https://download.pingcap.org/tidb-insight-v0.2.1.1.tar.gz
+    version: v0.2.1.1-1-gfbfc8b6
+    url: https://download.pingcap.org/tidb-insight-v0.2.1.1-1-gfbfc8b6.tar.gz


### PR DESCRIPTION
 - Add collecting of basic system information with `collector`
    - If multiple instances are deployed on one server, the last one run `collector` will overwrite former results
 - Add collecting of PD API info on pd instances
    - If multiple instances are deployed on one server, the output will be distinguished by hostname and listening port
 - Change download `tidb-insight` tarball name, remove the version number from it
