### PR TITLE
Update to latest tidb-insight, add feature to dump Prometheus metrics

### DIFF
--- a/collect_diagnosis.yml
+++ b/collect_diagnosis.yml
@@ -47,7 +47,7 @@
     - collector_tidb
 
 - name: collect prometheus metric data
-  host: monitoring_servers
+  hosts: monitoring_servers
   tags:
     - prometheus
   roles:

--- a/collect_diagnosis.yml
+++ b/collect_diagnosis.yml
@@ -46,6 +46,13 @@
   roles:
     - collector_tidb
 
+- name: collect prometheus metric data
+  host: monitoring_servers
+  tags:
+    - prometheus
+  roles:
+    - collector_prometheus
+
 - hosts: localhost
   tags:
     - always

--- a/roles/collector_pd/tasks/collect_config.yml
+++ b/roles/collector_pd/tasks/collect_config.yml
@@ -13,4 +13,4 @@
   when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
 
 - name: collect pd config
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --config-file --config-dir={{ pd_conf_dir }} --config-prefix=pd --output={{ pd_log_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} config --dir={{ pd_conf_dir }} --prefix=pd"

--- a/roles/collector_pd/tasks/collect_log.yml
+++ b/roles/collector_pd/tasks/collect_log.yml
@@ -9,4 +9,4 @@
   when: log_dir_st.stat.isdir is not defined or log_dir_st.stat.isdir == False
 
 - name: collect pd log
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --log-dir={{ pd_log_dir }} --log-prefix=pd --log-retention={{ collect_log_recent_hours | default('2') }} --output={{ pd_log_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} log --dir={{ pd_log_dir }} --prefix=pd --retention={{ collect_log_recent_hours | default('2') }}"

--- a/roles/collector_pd/tasks/main.yml
+++ b/roles/collector_pd/tasks/main.yml
@@ -14,13 +14,13 @@
 - include_tasks: collect_config.yml
 
 - name: collect PD information
-  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} --pdctl --pd-host={{ ansible_host }} --pd-port={{ pd_client_port }}
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} tidb pdctl --host={{ ansible_host }} --port={{ pd_client_port }}"
 
 - name: collect basic system information
-  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} --collector
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} system --collector"
 
 - name: compress collected data
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ pd_log_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ pd_log_dir }} --alias={{ inventory_hostname }} archive"
 
 - name: fetch pd diagnosis tarball with bandwidth limit
   delegate_to: localhost

--- a/roles/collector_prometheus/tasks/main.yml
+++ b/roles/collector_prometheus/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+
+- set_fact:
+    collector_dir: "{{ hostvars[groups.monitored_servers[0]].deploy_dir }}"
+    service_host: "{{ ansible_host }}"
+
+- name: create prometheus fetch directory
+  delegate_to: localhost
+  file: path={{ item }} state=directory mode=0755
+  with_items:
+    - "{{ fetch_tmp_dir }}/{{ service_host }}"
+
+- name: collect Prometheus metrics
+  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ prometheus_log_dir }} --alias={{ inventory_hostname }} metric prom --host={{ ansible_host }} --port={{ prometheus_port }} --retention {{ collect_log_recent_hours | default('2') }}
+
+- name: compress collected data
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ prometheus_log_dir }} --alias={{ inventory_hostname }}"
+
+- name: fetch prometheus diagnosis tarball with bandwidth limit
+  delegate_to: localhost
+  shell: "scp -P {{ ansible_port|default(22) }} -l {{ collect_bandwidth_limit|default('10000') }} -o StrictHostKeyChecking=no {{ service_host }}:{{ prometheus_log_dir }}/{{ inventory_hostname }}.tar.gz {{ fetch_tmp_dir }}/{{ service_host }}/prometheus_{{ inventory_hostname }}.tar.gz"
+  when: enable_bandwidth_limit|default(true)
+
+- name: fetch prometheus diagnosis tarball without bandwidth limit
+  fetch:
+    src: "{{ prometheus_log_dir }}/{{ inventory_hostname }}.tar.gz"
+    dest: "{{ fetch_tmp_dir }}/{{ service_host }}/prometheus_{{ inventory_hostname }}.tar.gz"
+    flat: yes
+  when: not enable_bandwidth_limit|default(true)
+
+- name: remove prometheus temporary diagnosis tarball
+  file:
+    path: "{{ prometheus_log_dir }}/{{ item }}"
+    state: absent
+  with_items:
+    - "{{ inventory_hostname }}.tar.gz"

--- a/roles/collector_prometheus/tasks/main.yml
+++ b/roles/collector_prometheus/tasks/main.yml
@@ -11,10 +11,10 @@
     - "{{ fetch_tmp_dir }}/{{ service_host }}"
 
 - name: collect Prometheus metrics
-  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ prometheus_log_dir }} --alias={{ inventory_hostname }} metric prom --host={{ ansible_host }} --port={{ prometheus_port }} --retention {{ collect_log_recent_hours | default('2') }}
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ prometheus_log_dir }} --alias={{ inventory_hostname }} metric prom --host={{ ansible_host }} --port={{ prometheus_port }} --retention {{ collect_log_recent_hours | default('2') }}"
 
 - name: compress collected data
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ prometheus_log_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ prometheus_log_dir }} --alias={{ inventory_hostname }} archive"
 
 - name: fetch prometheus diagnosis tarball with bandwidth limit
   delegate_to: localhost

--- a/roles/collector_prometheus/tasks/main.yml
+++ b/roles/collector_prometheus/tasks/main.yml
@@ -11,26 +11,26 @@
     - "{{ fetch_tmp_dir }}/{{ service_host }}"
 
 - name: collect Prometheus metrics
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ prometheus_log_dir }} --alias={{ inventory_hostname }} metric prom --host={{ ansible_host }} --port={{ prometheus_port }} --retention {{ collect_log_recent_hours | default('2') }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ deploy_dir }}/log --alias={{ inventory_hostname }} metric prom --host={{ ansible_host }} --port={{ prometheus_port }} --retention {{ collect_log_recent_hours | default('2') }}"
 
 - name: compress collected data
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ prometheus_log_dir }} --alias={{ inventory_hostname }} archive"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ deploy_dir }}/log --alias={{ inventory_hostname }} archive"
 
 - name: fetch prometheus diagnosis tarball with bandwidth limit
   delegate_to: localhost
-  shell: "scp -P {{ ansible_port|default(22) }} -l {{ collect_bandwidth_limit|default('10000') }} -o StrictHostKeyChecking=no {{ service_host }}:{{ prometheus_log_dir }}/{{ inventory_hostname }}.tar.gz {{ fetch_tmp_dir }}/{{ service_host }}/prometheus_{{ inventory_hostname }}.tar.gz"
+  shell: "scp -P {{ ansible_port|default(22) }} -l {{ collect_bandwidth_limit|default('10000') }} -o StrictHostKeyChecking=no {{ service_host }}:{{ deploy_dir }}/log/{{ inventory_hostname }}.tar.gz {{ fetch_tmp_dir }}/{{ service_host }}/prometheus_{{ inventory_hostname }}.tar.gz"
   when: enable_bandwidth_limit|default(true)
 
 - name: fetch prometheus diagnosis tarball without bandwidth limit
   fetch:
-    src: "{{ prometheus_log_dir }}/{{ inventory_hostname }}.tar.gz"
+    src: "{{ deploy_dir }}/log/{{ inventory_hostname }}.tar.gz"
     dest: "{{ fetch_tmp_dir }}/{{ service_host }}/prometheus_{{ inventory_hostname }}.tar.gz"
     flat: yes
   when: not enable_bandwidth_limit|default(true)
 
 - name: remove prometheus temporary diagnosis tarball
   file:
-    path: "{{ prometheus_log_dir }}/{{ item }}"
+    path: "{{ deploy_dir }}/log/{{ item }}"
     state: absent
   with_items:
     - "{{ inventory_hostname }}.tar.gz"

--- a/roles/collector_tidb/tasks/collect_config.yml
+++ b/roles/collector_tidb/tasks/collect_config.yml
@@ -14,4 +14,4 @@
   when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
 
 - name: collect tidb config
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --config-file --config-dir={{ tidb_conf_dir }} --config-prefix=tidb --output={{ tidb_log_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ tidb_log_dir }} --alias={{ inventory_hostname }} config --dir={{ tidb_conf_dir }} --prefix=tidb"

--- a/roles/collector_tidb/tasks/collect_log.yml
+++ b/roles/collector_tidb/tasks/collect_log.yml
@@ -9,4 +9,4 @@
   when: log_dir_st.stat.isdir is not defined or log_dir_st.stat.isdir == False
 
 - name: collect tidb log
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --log-dir={{ tidb_log_dir }} --log-prefix=tidb --log-retention={{ collect_log_recent_hours | default('2') }} --output={{ tidb_log_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ tidb_log_dir }} --alias={{ inventory_hostname }} log --dir={{ tidb_log_dir }} --prefix=tidb --retention={{ collect_log_recent_hours | default('2') }}"

--- a/roles/collector_tidb/tasks/main.yml
+++ b/roles/collector_tidb/tasks/main.yml
@@ -14,10 +14,10 @@
 - include_tasks: collect_config.yml
 
 - name: collect basic system information
-  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ tidb_log_dir }} --alias={{ inventory_hostname }} --collector
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ tidb_log_dir }} --alias={{ inventory_hostname }} system --collector"
 
 - name: compress collected data
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ tidb_log_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ tidb_log_dir }} --alias={{ inventory_hostname }} archive"
 
 - name: fetch tidb diagnosis tarball with bandwidth limit
   delegate_to: localhost

--- a/roles/collector_tikv/tasks/collect_config.yml
+++ b/roles/collector_tikv/tasks/collect_config.yml
@@ -14,4 +14,4 @@
   when: conf_dir_st.stat.isdir is not defined or conf_dir_st.stat.isdir == False
 
 - name: collect tikv config
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --config-file --config-dir={{ tikv_conf_dir }} --config-prefix=tikv --output={{ tikv_log_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ tikv_log_dir }} --alias={{ inventory_hostname }} config --dir={{ tikv_conf_dir }} --prefix=tikv"

--- a/roles/collector_tikv/tasks/collect_log.yml
+++ b/roles/collector_tikv/tasks/collect_log.yml
@@ -9,4 +9,4 @@
   when: log_dir_st.stat.isdir is not defined or log_dir_st.stat.isdir == False
 
 - name: collect tikv log
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py -l --log-dir={{ tikv_log_dir }} --log-prefix=tikv --log-retention={{ collect_log_recent_hours | default('2') }} --output={{ tikv_log_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ tikv_log_dir }} --alias={{ inventory_hostname }} log --dir={{ tikv_log_dir }} --prefix=tikv --retention={{ collect_log_recent_hours | default('2') }}"

--- a/roles/collector_tikv/tasks/main.yml
+++ b/roles/collector_tikv/tasks/main.yml
@@ -14,10 +14,10 @@
 - include_tasks: collect_config.yml
 
 - name: collect basic system information
-  shell: python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ tikv_log_dir }} --alias={{ inventory_hostname }} --collector
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ tikv_log_dir }} --alias={{ inventory_hostname }} system --collector"
 
 - name: compress collected data
-  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --compress --output={{ tikv_log_dir }} --alias={{ inventory_hostname }}"
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ tikv_log_dir }} --alias={{ inventory_hostname }} archive"
 
 - name: fetch tikv diagnosis tarball with bandwidth limit
   delegate_to: localhost

--- a/roles/local/templates/common_packages.yml.j2
+++ b/roles/local/templates/common_packages.yml.j2
@@ -33,5 +33,5 @@ common_packages:
 
 diagnosis_packages:
   - name: tidb-insight
-    version: v0.2.2
-    url: https://download.pingcap.org/tidb-insight-v0.2.2.tar.gz
+    version: v0.2.2-2-g36f06ae
+    url: https://download.pingcap.org/tidb-insight-v0.2.2-2-g36f06ae.tar.gz

--- a/roles/local/templates/common_packages.yml.j2
+++ b/roles/local/templates/common_packages.yml.j2
@@ -33,5 +33,5 @@ common_packages:
 
 diagnosis_packages:
   - name: tidb-insight
-    version: v0.2.1.1-4-gc03fa7b
-    url: https://download.pingcap.org/tidb-insight-v0.2.1.1-4-gc03fa7b.tar.gz
+    version: v0.2.2
+    url: https://download.pingcap.org/tidb-insight-v0.2.2.tar.gz


### PR DESCRIPTION
* Update to `tidb-insight`'s new sub-command strategy
* Add exporting of Prometheus metrics, which can be them used for offline analysis