### PR TITLE
tidb-insight: add support of collecting of TiDB server info

### DIFF
--- a/roles/collector_tidb/tasks/main.yml
+++ b/roles/collector_tidb/tasks/main.yml
@@ -16,6 +16,10 @@
 - name: collect basic system information
   shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ tidb_log_dir }} --alias={{ inventory_hostname }} system --collector"
 
+- name: collect tidb server information
+  shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ tidb_log_dir }} --alias={{ inventory_hostname }} tidb tidbinfo"
+  run_once: True
+
 - name: compress collected data
   shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ tidb_log_dir }} --alias={{ inventory_hostname }} archive"
 

--- a/roles/local/templates/common_packages.yml.j2
+++ b/roles/local/templates/common_packages.yml.j2
@@ -33,5 +33,5 @@ common_packages:
 
 diagnosis_packages:
   - name: tidb-insight
-    version: v0.2.2-2-g36f06ae
-    url: https://download.pingcap.org/tidb-insight-v0.2.2-2-g36f06ae.tar.gz
+    version: v0.2.3
+    url: https://download.pingcap.org/tidb-insight-v0.2.3.tar.gz


### PR DESCRIPTION
Collects TiDB server info from the TiDB server info API.

Note: This feature does not work on TiDB versions prior to v2.1 and will get empty result.