### PR TITLE
scripts: update DDL metrics

### DIFF
--- a/scripts/tidb.json
+++ b/scripts/tidb.json
@@ -5322,10 +5322,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(increase(tidb_ddl_worker_operation_duration_seconds_bucket[1m])) by (le, type, result))",
+              "expr": "histogram_quantile(0.99, sum(increase(tidb_ddl_worker_operation_duration_seconds_bucket[1m])) by (le, type, action, result))",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{type}}-{{result}}",
+              "legendFormat": "{{type}}-{{action}}-{{result}}",
               "refId": "A"
             }
           ],
@@ -5476,10 +5476,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(1, sum(rate(tidb_ddl_owner_handle_syncer_duration_seconds_bucket[2m])) by (le, type, result))",
+              "expr": "histogram_quantile(1, sum(rate(tidb_ddl_owner_handle_syncer_duration_seconds_bucket[1m])) by (le, type, version, result))",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{type}}-{{result}}",
+              "legendFormat": "{{type}}-{{version}}-{{result}}",
               "refId": "A"
             }
           ],
@@ -5553,10 +5553,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(1, sum(rate(tidb_ddl_update_self_ver_duration_seconds_bucket[2m])) by (le, result))",
+              "expr": "histogram_quantile(1, sum(rate(tidb_ddl_update_self_ver_duration_seconds_bucket[1m])) by (le,version, result))",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{result}}",
+              "legendFormat": "{{version}}-{{result}}",
               "refId": "A"
             }
           ],

--- a/scripts/tidb.json
+++ b/scripts/tidb.json
@@ -5476,10 +5476,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(1, sum(rate(tidb_ddl_owner_handle_syncer_duration_seconds_bucket[1m])) by (le, type, version, result))",
+              "expr": "histogram_quantile(1, sum(rate(tidb_ddl_owner_handle_syncer_duration_seconds_bucket[2m])) by (le, type, result))",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{type}}-{{version}}-{{result}}",
+              "legendFormat": "{{type}}-{{result}}",
               "refId": "A"
             }
           ],
@@ -5553,10 +5553,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(1, sum(rate(tidb_ddl_update_self_ver_duration_seconds_bucket[1m])) by (le,version, result))",
+              "expr": "histogram_quantile(1, sum(rate(tidb_ddl_update_self_ver_duration_seconds_bucket[2m])) by (le, result))",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{version}}-{{result}}",
+              "legendFormat": "{{result}}",
               "refId": "A"
             }
           ],


### PR DESCRIPTION
Add job action and schema version information to DDL metrics.

Merge after pingcap/tidb#7472

![screen shot 2018-08-28 at 10 46 37](https://user-images.githubusercontent.com/4242506/44697780-e8691680-aaaf-11e8-8601-24f54659d617.png)
![screen shot 2018-08-28 at 10 46 46](https://user-images.githubusercontent.com/4242506/44697791-f61e9c00-aaaf-11e8-9fea-51eee4ad47a2.png)

