### PR TITLE
check: Linux kernel vm.overcommit_memory parameter

### DIFF
--- a/roles/check_system_static/tasks/main.yml
+++ b/roles/check_system_static/tasks/main.yml
@@ -38,6 +38,7 @@
 
 - name: Preflight check - Check Linux kernel overcommit_memory parameter
   shell: "sysctl -n vm.overcommit_memory"
+  become: true
   register: vm_overcommit_memory
 
 - name: Preflight check - Fail when Linux kernel vm.overcommit_memory parameter is set to 2

--- a/roles/check_system_static/tasks/main.yml
+++ b/roles/check_system_static/tasks/main.yml
@@ -44,4 +44,4 @@
 - name: Preflight check - Fail when Linux kernel vm.overcommit_memory parameter is set to 2
   fail:
     msg: "To avoid OOM, it is not recommended to set vm.overcommit_memory to 2, set it to 0 or 1."
-  when: vm_overcommit_memory == 2
+  when: vm_overcommit_memory.stdout | int == 2

--- a/roles/check_system_static/tasks/main.yml
+++ b/roles/check_system_static/tasks/main.yml
@@ -35,3 +35,12 @@
 
 - name: Clean check_cpufreq script
   file: path={{ deploy_dir }}/check_cpufreq.py state=absent
+
+- name: Preflight check - Check Linux kernel overcommit_memory parameter
+  shell: "sysctl -n vm.overcommit_memory"
+  register: vm_overcommit_memory
+
+- name: Preflight check - Fail when Linux kernel vm.overcommit_memory parameter is set to 2
+  fail:
+    msg: "To avoid OOM, it is not recommended to set vm.overcommit_memory to 2, set it to 0 or 1."
+  when: vm_overcommit_memory == 2

--- a/roles/check_system_static/tasks/main.yml
+++ b/roles/check_system_static/tasks/main.yml
@@ -43,5 +43,5 @@
 
 - name: Preflight check - Fail when Linux kernel vm.overcommit_memory parameter is set to 2
   fail:
-    msg: "To avoid OOM, it is not recommended to set vm.overcommit_memory to 2, set it to 0 or 1."
+    msg: "It is not recommended to set vm.overcommit_memory to 2, set it to 0 or 1."
   when: vm_overcommit_memory.stdout | int == 2


### PR DESCRIPTION
Fail task when Linux kernel vm.overcommit_memory parameter is set to 2.