### PR TITLE
fix tidb download url

### DIFF
--- a/roles/local/templates/common_packages.yml.j2
+++ b/roles/local/templates/common_packages.yml.j2
@@ -3,7 +3,7 @@
 tidb_packages:
   - name: tidb
     version: {{ tidb_version }}
-    url: http://download.pingcap.org/tidb-{{ tidb_version }}-linux-amd64-unportable.tar.gz
+    url: http://download.pingcap.org/tidb-{{ tidb_version }}-linux-amd64.tar.gz
 {% if not deploy_without_tidb|default(false) %}
   - name: tidb-binlog
     version: latest


### PR DESCRIPTION
Fixed download URL link for TiDB binary release.