### PR TITLE
tidb-insight: collect tidb info for every instance

### DIFF
--- a/roles/collector_tidb/tasks/main.yml
+++ b/roles/collector_tidb/tasks/main.yml
@@ -18,7 +18,6 @@
 
 - name: collect tidb server information
   shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ tidb_log_dir }} --alias={{ inventory_hostname }} tidb tidbinfo"
-  run_once: True
 
 - name: compress collected data
   shell: "python {{ collector_dir }}/scripts/tidb-insight/insight.py --output={{ tidb_log_dir }} --alias={{ inventory_hostname }} archive"

--- a/roles/local/templates/common_packages.yml.j2
+++ b/roles/local/templates/common_packages.yml.j2
@@ -33,5 +33,5 @@ common_packages:
 
 diagnosis_packages:
   - name: tidb-insight
-    version: v0.2.4
-    url: http://download.pingcap.org/tidb-insight-v0.2.4.tar.gz
+    version: v0.2.4-4-gcaa54a6
+    url: http://download.pingcap.org/tidb-insight-v0.2.4-4-gcaa54a6.tar.gz


### PR DESCRIPTION
New version of `tidb-insight` doesn't only collect the whole tidb cluster's info with one API, but queries more info that only works with one server.

The `/info/all` is still collected (and thus duplicated as every server should report the same content), it can be used to comparing with `/info` from every server, to find if there's any TiDB instance not included in the `inventory.ini`.