### PR TITLE
systemd: add MemoryLimit setting

### DIFF
--- a/roles/systemd/templates/systemd_binary.service.j2
+++ b/roles/systemd/templates/systemd_binary.service.j2
@@ -3,6 +3,9 @@ Description={{ service_name }} service
 After=syslog.target network.target remote-fs.target nss-lookup.target
 
 [Service]
+{% if MemoryLimit|default("") %}
+MemoryLimit={{ MemoryLimit }}
+{% endif %}
 LimitNOFILE=1000000
 #LimitCORE=infinity
 LimitSTACK=10485760


### PR DESCRIPTION
Add limits on the unit's memory consumption, It's optional.

example:

```
[tidb_servers]
tidb1 ansible_host=172.16.10.72 MemoryLimit=2G
```

MemoryLimit=value
Replace value with a limit on maximum memory usage of the processes executed in the cgroup. Use suffixes K, M, G, or T to identify Kilobyte, Megabyte, Gigabyte, or Terabyte as the unit of measurement. Also, the MemoryAccounting parameter has to be enabled for the unit.

```
# systemctl status tidb-4000.service
● tidb-4000.service - tidb-4000 service
   Loaded: loaded (/etc/systemd/system/tidb-4000.service; disabled; vendor preset: disabled)
   Active: active (running) since 日 2018-10-14 04:32:13 CST; 23s ago
 Main PID: 27238 (tidb-server)
   Memory: 25.9M (limit: 2.0G)
   CGroup: /system.slice/tidb-4000.service
           └─27238 /usr/bin/tidb-server -P 4000 --status=10080 --advertise-address=172.16.10.72 --path=172.16.10.72:2379,172.16.10.73:2379,172.16.10.74:237...

10月 14 04:32:13 ip-172-16-10-72 systemd[1]: Started tidb-4000 service.
10月 14 04:32:13 ip-172-16-10-72 systemd[1]: Starting tidb-4000 service...
```