### PR TITLE
machine_benchmark: fix randread and sequential write benchmark for latency

### DIFF
--- a/roles/machine_benchmark/tasks/fio_randread_write.yml
+++ b/roles/machine_benchmark/tasks/fio_randread_write.yml
@@ -21,18 +21,6 @@
   args:
     chdir: "{{ fio_deploy_dir }}/"
 
-- name: get fio mixed test randread latency
-  shell: "python parse_fio_output.py --target='fio_randread_write_test.json' --read-lat"
-  register: disk_mix_randread_lat
-  args:
-    chdir: "{{ fio_deploy_dir }}/"
-
-- name: get fio mixed test write latency
-  shell: "python parse_fio_output.py --target='fio_randread_write_test.json' --write-lat"
-  register: disk_mix_write_lat
-  args:
-    chdir: "{{ fio_deploy_dir }}/"
-
 - name: get fio mixed randread and sequential write summary
   shell: "python parse_fio_output.py --target='fio_randread_write_test.json' --summary"
   register: disk_mix_randread_write_smmary
@@ -57,13 +45,3 @@
   fail:
     msg: 'fio mixed randread and sequential write test: sequential write iops of tikv_data_dir disk is too low: {{ disk_mix_write_iops.stdout }} < {{ min_ssd_mix_write_iops }}, it is strongly recommended to use SSD disks for TiKV and PD, or there might be performance issues.'
   when: disk_mix_write_iops.stdout|int < min_ssd_mix_write_iops|int
-
-- name: Preflight check - Does fio mixed randread and sequential write latency of tikv_data_dir disk meet requirement - randread
-  fail:
-    msg: 'fio mixed randread and sequential write test: randread latency of  tikv_data_dir disk is too low: {{ disk_mix_randread_lat.stdout }} ns > {{ max_ssd_mix_randread_lat }} ns, it is strongly recommended to use SSD disks for TiKV and PD, or there might be performance issues.'
-  when: disk_mix_randread_lat.stdout|int > max_ssd_mix_randread_lat|int
-
-- name: Preflight check - Does fio mixed randread and sequential write latency of tikv_data_dir disk meet requirement - sequential write
-  fail:
-    msg: 'fio mixed randread and sequential write test: sequential write latency of tikv_data_dir disk is too low: {{ disk_mix_write_lat.stdout }} ns > {{ max_ssd_mix_write_lat }} ns, it is strongly recommended to use SSD disks for TiKV and PD, or there might be performance issues.'
-  when: disk_mix_write_lat.stdout|int > max_ssd_mix_write_lat|int

--- a/roles/machine_benchmark/tasks/fio_randread_write_latency.yml
+++ b/roles/machine_benchmark/tasks/fio_randread_write_latency.yml
@@ -1,0 +1,47 @@
+---
+
+- name: fio mixed randread and sequential write benchmark for latency on tikv_data_dir disk
+  shell: "cd {{ fio_deploy_dir }} && ./fio -ioengine=psync -bs=32k -fdatasync=1 -thread -rw=randrw -percentage_random=100,0 -size={{ benchmark_size }} -filename=fio_randread_write_latency_test.txt -name='fio mixed randread and sequential write test' -iodepth=1 -runtime=60 -numjobs=1 -group_reporting --output-format=json --output=fio_randread_write_latency_test.json"
+  register: fio_randread_write_latency
+
+- name: clean fio mixed randread and sequential write benchmark for latency temporary file
+  file:
+    path: "{{ fio_deploy_dir }}/fio_randread_write_latency_test.txt"
+    state: absent
+
+- name: get fio mixed test randread latency
+  shell: "python parse_fio_output.py --target='fio_randread_write_latency_test.json' --read-lat"
+  register: disk_mix_randread_lat
+  args:
+    chdir: "{{ fio_deploy_dir }}/"
+
+- name: get fio mixed test write latency
+  shell: "python parse_fio_output.py --target='fio_randread_write_latency_test.json' --write-lat"
+  register: disk_mix_write_lat
+  args:
+    chdir: "{{ fio_deploy_dir }}/"
+
+- name: get fio mixed randread and sequential write for latency summary
+  shell: "python parse_fio_output.py --target='fio_randread_write_latency_test.json' --summary"
+  register: disk_mix_randread_write_latency_smmary
+  args:
+    chdir: "{{ fio_deploy_dir }}/"
+
+- name: fio mixed randread and sequential write benchmark for latency command
+  debug:
+    msg: "fio mixed randread and sequential write benchmark for latency command: {{ fio_randread_write_latency.cmd }}."
+  run_once: true
+
+- name: fio mixed randread and sequential write benchmark for latency summary
+  debug:
+    msg: "fio mixed randread and sequential write benchmark summary: {{ disk_mix_randread_write_latency_smmary.stdout }}."
+
+- name: Preflight check - Does fio mixed randread and sequential write latency of tikv_data_dir disk meet requirement - randread
+  fail:
+    msg: 'fio mixed randread and sequential write test: randread latency of  tikv_data_dir disk is too low: {{ disk_mix_randread_lat.stdout }} ns > {{ max_ssd_mix_randread_lat }} ns, it is strongly recommended to use SSD disks for TiKV and PD, or there might be performance issues.'
+  when: disk_mix_randread_lat.stdout|int > max_ssd_mix_randread_lat|int
+
+- name: Preflight check - Does fio mixed randread and sequential write latency of tikv_data_dir disk meet requirement - sequential write
+  fail:
+    msg: 'fio mixed randread and sequential write test: sequential write latency of tikv_data_dir disk is too low: {{ disk_mix_write_lat.stdout }} ns > {{ max_ssd_mix_write_lat }} ns, it is strongly recommended to use SSD disks for TiKV and PD, or there might be performance issues.'
+  when: disk_mix_write_lat.stdout|int > max_ssd_mix_write_lat|int

--- a/roles/machine_benchmark/tasks/main.yml
+++ b/roles/machine_benchmark/tasks/main.yml
@@ -27,3 +27,5 @@
 - include_tasks: fio_randread.yml
 
 - include_tasks: fio_randread_write.yml
+
+- include_tasks: fio_randread_write_latency.yml


### PR DESCRIPTION
"fio_randread_write.yml" split  is split into "fio_randread_write.yml" and "fio_randread_write_latency.yml"
@LinuxGit @liubo0127 PTAL