### PR TITLE
tidb-insight: add sytem uptime and process start time

### DIFF
--- a/roles/local/templates/common_packages.yml.j2
+++ b/roles/local/templates/common_packages.yml.j2
@@ -33,5 +33,5 @@ common_packages:
 
 diagnosis_packages:
   - name: tidb-insight
-    version: v0.2.5
-    url: http://download.pingcap.org/tidb-insight-v0.2.5.tar.gz
+    version: v0.2.5-1-g99b8fea
+    url: http://download.pingcap.org/tidb-insight-v0.2.5-1-g99b8fea.tar.gz


### PR DESCRIPTION
This `tidb-insight` package adds feature to collect system uptime and process start time for TiDB modules.

See https://github.com/pingcap/tidb-insight/pull/48 for details.