### PR TITLE
grafana: fix inconsistent radix units

### DIFF
--- a/scripts/overview.json
+++ b/scripts/overview.json
@@ -524,7 +524,7 @@
           "decimals": null,
           "editable": true,
           "error": false,
-          "format": "bytes",
+          "format": "decbytes",
           "gauge": {
             "maxValue": 100,
             "minValue": 0,
@@ -602,7 +602,7 @@
           "decimals": 1,
           "editable": true,
           "error": false,
-          "format": "bytes",
+          "format": "decbytes",
           "gauge": {
             "maxValue": 100,
             "minValue": 0,
@@ -3440,7 +3440,7 @@
           },
           "yaxes": [
             {
-              "format": "bytes",
+              "format": "decbytes",
               "label": null,
               "logBase": 1,
               "max": null,


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

Change 3 `bytes` to `decbytes`:
- make `Storage Capacity` same as `PD`
- make `Current Storage Size` same as `PD`
- make `cf size` same as `TiKV`