### PR TITLE
Add tikv_engine_stall_conditions_changed to metrics;

### DIFF
--- a/scripts/tikv.json
+++ b/scripts/tikv.json
@@ -14391,6 +14391,7 @@
             "alignAsTable": true,
             "avg": false,
             "current": true,
+            "hideZero": true,
             "max": true,
             "min": true,
             "rightSide": true,
@@ -14420,7 +14421,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(tikv_engine_stall_conditions_changed{job=~\"$job\",db=\"$db\"}) by (cf, type)",
+              "expr": "tikv_engine_stall_conditions_changed{job=~\"$job\",db=\"$db\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{cf}}-{{type}}",

--- a/scripts/tikv.json
+++ b/scripts/tikv.json
@@ -14378,6 +14378,90 @@
               "show": true
             }
           ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "fill": 1,
+          "id": 2381,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "scopedVars": {
+            "db": {
+              "selected": false,
+              "text": "kv",
+              "value": "kv"
+            }
+          },
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "avg(tikv_engine_stall_conditions_changed{job=~\"$job\",db=\"$db\"}) by (cf, type)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{cf}}-{{type}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Stall conditions changed of each CF",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
         }
       ],
       "repeat": "db",

--- a/scripts/tikv.json
+++ b/scripts/tikv.json
@@ -14424,7 +14424,7 @@
               "expr": "tikv_engine_stall_conditions_changed{job=~\"$job\",db=\"$db\"}",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{cf}}-{{type}}",
+              "legendFormat": "{{job}}-{{cf}}-{{type}}",
               "refId": "B"
             }
           ],


### PR DESCRIPTION
Based on [TiKV 3712](https://github.com/tikv/tikv/pull/3712). 
If `triggered_writes_slowdown` is 1, then rocksdb is currently slowing-down all writes to prevent creating too many Level 0 files as compaction seems not able to catch up the write request speed.
If `triggered_writes_stop` is 1, then rocksdb is currently blocking any writes to prevent creating more L0 files.
3 states `normal`, `delayed`, `stopped` of RocsDB are shown.