### PR TITLE
conf: set right default capacity value for tidb txn_local_latches

### DIFF
--- a/conf/tidb.yml
+++ b/conf/tidb.yml
@@ -207,7 +207,7 @@ txn_local_latches:
   # Enable local latches for transactions. Enable it when
   # there are lots of conflicts between transactions.
   # enabled: true
-  # capacity: 20480000
+  # capacity: 2048000
 
 binlog:
   # WriteTimeout specifies how long it will wait for writing binlog to pump.

--- a/roles/tidb/vars/default.yml
+++ b/roles/tidb/vars/default.yml
@@ -225,7 +225,7 @@ txn_local_latches:
   # Enable local latches for transactions. Enable it when
   # there are lots of conflicts between transactions.
   enabled: true
-  capacity: 20480000
+  capacity: 2048000
 
 binlog:
   # Socket file to write binlog.


### PR DESCRIPTION
current ansible default value for latches is too big and cause huge memory usage..

we need set default value follow tidb's one ref https://github.com/pingcap/tidb/blob/2f2b47f511f8311907af26314196a82dd254caf4/config/config.go#L270

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb-ansible/600)
<!-- Reviewable:end -->
