### PR TITLE
pd: update merge configurations

### DIFF
--- a/roles/pd/vars/default.yml
+++ b/roles/pd/vars/default.yml
@@ -55,8 +55,6 @@ log:
 metric:
 
 schedule:
-  max-merge-region-size: 0
-  max-merge-region-keys: 0
   split-merge-interval: "1h"
   max-snapshot-count: 3
   max-pending-peer-count: 16


### PR DESCRIPTION
After https://github.com/pingcap/pd/pull/1334, the configurations explicitly set to zero values will not adjust to default values. We need to remove them to make it work the same way as before.