### PR TITLE
pd: alert if there is no store to make replicas

### DIFF
--- a/roles/prometheus/files/pd.rules.yml
+++ b/roles/prometheus/files/pd.rules.yml
@@ -156,3 +156,15 @@ groups:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values: {{ $value }}'
       value: '{{ $value }}'
       summary: PD_system_time_slow
+
+  - alert: PD_no_store_for_making_replica
+    expr: increase(pd_checker_event_count{type="replica_checker", name="no_target_store"}[1m]) > 0
+    for: 1m
+    labels:
+      env: ENV_LABELS_ENV
+      level: warning
+      expr: increase(pd_checker_event_count{type="replica_checker", name="no_target_store"}[1m]) > 0
+    annotations:
+      description: 'cluster: ENV_LABELS_ENV, type: {{ $labels.type }}, instance: {{ $labels.instance }}, values: {{ $value }}'
+      value: '{{ $value }}'
+      summary: PD_no_store_for_making_replica


### PR DESCRIPTION
This PR is used to alert if there is no store to make replicas for a while.