### PR TITLE
Support titan config section

### DIFF
--- a/conf/tikv.yml
+++ b/conf/tikv.yml
@@ -369,6 +369,24 @@ rocksdb:
   ## absolute path will be used as the log file name's prefix.
   # info-log-dir: ""
 
+  ## Options for "Titan"
+  titan:
+    ## Enables `Titan`
+    ## default: false
+    # enabled: false
+
+    ## Specifies `Titan` blob files directory
+    ## default: "titandb" (if not specific or empty)
+    # dirname: ""
+
+    ## Disable blob file gc
+    ## default: false
+    # disable-gc: false
+
+    ## Maximum number of threads of `Titan` background gc jobs.
+    ## default: 1
+    # max-background-gc: 1
+
   ## Options for "Default" Column Family, which stores actual user data.
   defaultcf:
     ## Compression method (if any) is used to compress a block.
@@ -499,6 +517,53 @@ rocksdb:
 
     ## Pick target size of each level dynamically.
     # dynamic-level-bytes: true
+
+    ## Options for "Titan" for "Default" Column Family
+    titan:
+      ## The smallest value to store in blob files. Value smaller than
+      ## this threshold will be inlined in base DB.
+      ## default: 1KB
+      # min-blob-size: "1KB"
+
+      ## The compression algorithm used to compress data in blob files.
+      ## Compression method.
+      ##   no:     kNoCompression
+      ##   snappy: kSnappyCompression
+      ##   zlib:   kZlibCompression
+      ##   bzip2:  kBZip2Compression
+      ##   lz4:    kLZ4Compression
+      ##   lz4hc:  kLZ4HCCompression
+      ##   zstd:   kZSTD
+      ## default: lz4
+      # blob-file-compression: "lz4"
+
+      ## Specifics cache size for blob records
+      ## default: 0
+      # blob-cache-size: "0GB"
+
+      ## The minimum batch size of one gc job. The total blob file size
+      ## of one gc job cannot smaller than this threshold.
+      ## default: 16MB
+      # min-gc-batch-size: "16MB"
+
+      ## The maximum batch size of one gc job. The total blob file size
+      ## of one gc job cannot exceed this threshold.
+      # max-gc-batch-size: "64MB"
+
+      ## If the ratio of discardable size of a blob file is larger than
+      ## this threshold, the blob file will be GCed out.
+      ## default: 0.5
+      # discardable-ratio: 0.5
+
+      ## The gc job will sample the target blob files to see if its
+      ## discardable ratio is smaller than discardable-ratio metioned
+      ## above before gc start, if so the blob file will be exclude.
+      # sample-ratio: 0.1
+
+      ## If the size of the blob file is smaller than this threshold,
+      ## the blob file will be merge.
+      ## default: 8MB
+      # merge-small-file-threshold: "8MB"
 
   ## Options for "Write" Column Family, which stores MVCC commit information
   writecf:

--- a/roles/tikv/templates/tikv.toml.j2
+++ b/roles/tikv/templates/tikv.toml.j2
@@ -64,7 +64,15 @@
 
 [rocksdb.{{ item }}]
 {% for sub_item, sub_value in value | dictsort -%}
+{% if sub_value is not mapping -%}
 {{ sub_item }} = {{ sub_value | to_json }}
+{% else %}
+
+[rocksdb.{{ item }}.{{sub_item}}]
+{% for sub_sub_item, sub_sub_value in sub_value | dictsort -%}
+{{ sub_sub_item }} = {{ sub_sub_value | to_json }}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% endif %}
 {% endfor %}

--- a/roles/tikv/vars/default.yml
+++ b/roles/tikv/vars/default.yml
@@ -369,6 +369,24 @@ rocksdb:
   ## absolute path will be used as the log file name's prefix.
   # info-log-dir: ""
 
+  ## Options for "Titan"
+  titan:
+  ## Enables `Titan`
+  ## default: false
+  # enabled: false
+
+  ## Specifies `Titan` blob files directory
+  ## default: "titandb" (if not specific or empty)
+  # dirname: ""
+
+  ## Disable blob file gc
+  ## default: false
+  # disable-gc: false
+
+  ## Maximum number of threads of `Titan` background gc jobs.
+  ## default: 1
+  # max-background-gc: 1
+
   ## Options for "Default" Column Family, which stores actual user data.
   defaultcf:
     ## Compression method (if any) is used to compress a block.
@@ -499,6 +517,53 @@ rocksdb:
 
     ## Pick target size of each level dynamically.
     # dynamic-level-bytes: true
+
+    ## Options for "Titan" for "Default" Column Family
+    titan:
+    ## The smallest value to store in blob files. Value smaller than
+    ## this threshold will be inlined in base DB.
+    ## default: 1KB
+    # min-blob-size: "1KB"
+
+    ## The compression algorithm used to compress data in blob files.
+    ## Compression method.
+    ##   no:     kNoCompression
+    ##   snappy: kSnappyCompression
+    ##   zlib:   kZlibCompression
+    ##   bzip2:  kBZip2Compression
+    ##   lz4:    kLZ4Compression
+    ##   lz4hc:  kLZ4HCCompression
+    ##   zstd:   kZSTD
+    ## default: lz4
+    # blob-file-compression: "lz4"
+
+    ## Specifics cache size for blob records
+    ## default: 0
+    # blob-cache-size: "0GB"
+
+    ## The minimum batch size of one gc job. The total blob file size
+    ## of one gc job cannot smaller than this threshold.
+    ## default: 16MB
+    # min-gc-batch-size: "16MB"
+
+    ## The maximum batch size of one gc job. The total blob file size
+    ## of one gc job cannot exceed this threshold.
+    # max-gc-batch-size: "64MB"
+
+    ## If the ratio of discardable size of a blob file is larger than
+    ## this threshold, the blob file will be GCed out.
+    ## default: 0.5
+    # discardable-ratio: 0.5
+
+    ## The gc job will sample the target blob files to see if its
+    ## discardable ratio is smaller than discardable-ratio metioned
+    ## above before gc start, if so the blob file will be exclude.
+    # sample-ratio: 0.1
+
+    ## If the size of the blob file is smaller than this threshold,
+    ## the blob file will be merge.
+    ## default: 8MB
+    # merge-small-file-threshold: "8MB"
 
   ## Options for "Write" Column Family, which stores MVCC commit information
   writecf:


### PR DESCRIPTION
`Titan` section is third degree section, so we need to make `tikv.toml.j2` to support third degree section.