### PR TITLE
Add tikv jemalloc stats to Grafana

### DIFF
--- a/scripts/tikv_pull.json
+++ b/scripts/tikv_pull.json
@@ -15801,7 +15801,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "tikv_jemalloc_stats",
+              "expr": "tikv_jemalloc_stats{instance=~\"$instance\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,

--- a/scripts/tikv_pull.json
+++ b/scripts/tikv_pull.json
@@ -15762,6 +15762,96 @@
       "showTitle": true,
       "title": "PD",
       "titleSize": "h6"
+    },
+    {
+      "collapse": true,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "fill": 1,
+          "id": 2696,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "rightSide": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "tikv_jemalloc_stats",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{type}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Jemalloc Stats",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "decbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Memory",
+      "titleSize": "h6"
     }
   ],
   "schemaVersion": 14,


### PR DESCRIPTION
Add tikv jemalloc stats to Grafana. Depends on https://github.com/tikv/tikv/pull/4332.

Screenshot:
<img width="982" alt="Screen Shot 2019-03-11 at 11 49 42 AM" src="https://user-images.githubusercontent.com/2606959/54149783-31e9d500-43f4-11e9-9f65-e684a0adbdfc.png">
