### PR TITLE
Make it possible to have two cluster running on the same machine

### DIFF
--- a/graceful_stop.yml
+++ b/graceful_stop.yml
@@ -310,7 +310,7 @@
       when: process_supervision == 'supervise'
 
     - name: stop PD by systemd
-      systemd: name=pd.service state=stopped
+      systemd: name=pd-{{ pd_client_port }}.service state=stopped
       become: true
       when: process_supervision == 'systemd'
 

--- a/group_vars/alertmanager_servers.yml
+++ b/group_vars/alertmanager_servers.yml
@@ -1,3 +1,4 @@
 ---
 
 alertmanager_port: 9093
+alertmanager_mesh_port: 9094

--- a/roles/alertmanager/templates/run_alertmanager_binary.sh.j2
+++ b/roles/alertmanager/templates/run_alertmanager_binary.sh.j2
@@ -15,4 +15,5 @@ exec bin/alertmanager \
     --storage.path="{{ alertmanager_data_dir }}" \
     --data.retention=120h \
     --log.level="{{ alertmanager_log_level }}" \
-    --web.listen-address=":{{ alertmanager_port }}"
+    --web.listen-address=":{{ alertmanager_port }}" \
+    --mesh.listen-address=":{{ alertmanager_mesh_port }}"

--- a/roles/alertmanager/templates/run_alertmanager_docker.sh.j2
+++ b/roles/alertmanager/templates/run_alertmanager_docker.sh.j2
@@ -8,6 +8,7 @@ DEPLOY_DIR={{ deploy_dir }}
 cd "${DEPLOY_DIR}" || exit 1
 
 exec docker run -p {{ alertmanager_port }}:9093 \
+  -p {{ alertmanager_mesh_port }}:9094
   -v /etc/localtime:/etc/localtime:ro \
   -v "{{ alertmanager_data_dir }}:/alertmanager" \
   -v "{{ deploy_dir }}/conf/alertmanager.yml:/etc/alertmanager/config.yml" \
@@ -18,3 +19,4 @@ exec docker run -p {{ alertmanager_port }}:9093 \
   --storage.path="/alertmanager" \
   --data.retention=120h \
   --log.level="{{ alertmanager_log_level }}"
+  --mesh.listen-address=":9094"

--- a/roles/pd/tasks/supervise_deployment.yml
+++ b/roles/pd/tasks/supervise_deployment.yml
@@ -5,4 +5,4 @@
     name: supervise
   vars:
     this_role_name: pd
-    service_name: pd
+    service_name: pd-{{ pd_client_port }}

--- a/roles/pd/tasks/systemd_deployment.yml
+++ b/roles/pd/tasks/systemd_deployment.yml
@@ -5,4 +5,4 @@
     name: systemd
   vars:
     this_role_name: pd
-    service_name: pd
+    service_name: pd-{{ pd_client_port }}

--- a/rolling_update.yml
+++ b/rolling_update.yml
@@ -73,7 +73,7 @@
       when: process_supervision == 'supervise'
 
     - name: stop PD by systemd
-      systemd: name=pd.service state=stopped
+      systemd: name=pd-{{ pd_client_port }}.service state=stopped
       become: true
       when: process_supervision == 'systemd'
 
@@ -93,7 +93,7 @@
       when: process_supervision == 'supervise'
 
     - name: start PD by systemd
-      systemd: name=pd.service state=started
+      systemd: name=pd-{{ pd_client_port }}.service state=started
       become: true
       when: process_supervision == 'systemd'
 
@@ -263,7 +263,7 @@
         port: "{{ pump_port }}"
         state: stopped
         msg: "the pump port {{ pump_port }} is not down"
-      when: 
+      when:
         - enable_binlog|default(false)
         - binlog_version == "cluster"
 

--- a/start.yml
+++ b/start.yml
@@ -213,7 +213,7 @@
         - pd
 
     - name: start PD by systemd
-      systemd: name=pd.service state=started enabled=no
+      systemd: name=pd-{{ pd_client_port }}.service state=started enabled=no
       become: true
       when: process_supervision == 'systemd'
 

--- a/stop.yml
+++ b/stop.yml
@@ -272,7 +272,7 @@
         - pd
 
     - name: stop PD by systemd
-      systemd: name=pd.service state=stopped
+      systemd: name=pd-{{ pd_client_port }}.service state=stopped
       become: true
       when: process_supervision == 'systemd'
 

--- a/unsafe_cleanup.yml
+++ b/unsafe_cleanup.yml
@@ -101,7 +101,7 @@
       become: true
       when: process_supervision == 'systemd'
       with_items:
-        - pd.service
+        - pd-{{ pd_client_port }}.service
 
 - hosts: grafana_servers
   tasks:

--- a/unsafe_cleanup_data.yml
+++ b/unsafe_cleanup_data.yml
@@ -140,7 +140,7 @@
     - pd
 
   - name: stop PD by systemd
-    systemd: name=pd.service state=stopped
+    systemd: name=pd-{{ pd_client_port }}.service state=stopped
     become: true
     when: process_supervision == 'systemd'
 


### PR DESCRIPTION
- Put the port into the name of the pd service. This allows multiple pds to be deployed on the same machine.
- Make the mesh port (or cluster port) of alertmanager configurable. This allows multiple alertmanagers to be deployed on the same machine.