### PR TITLE
Add more resource control settings

### DIFF
--- a/roles/systemd/templates/systemd_binary.service.j2
+++ b/roles/systemd/templates/systemd_binary.service.j2
@@ -6,6 +6,9 @@ After=syslog.target network.target remote-fs.target nss-lookup.target
 {% if MemoryLimit|default("") %}
 MemoryLimit={{ MemoryLimit }}
 {% endif %}
+{% if CPUQuota|default("") %}
+CPUQuota={{ CPUQuota }}
+{% endif %}
 LimitNOFILE=1000000
 #LimitCORE=infinity
 LimitSTACK=10485760

--- a/roles/systemd/templates/systemd_binary.service.j2
+++ b/roles/systemd/templates/systemd_binary.service.j2
@@ -9,6 +9,12 @@ MemoryLimit={{ MemoryLimit }}
 {% if CPUQuota|default("") %}
 CPUQuota={{ CPUQuota }}
 {% endif %}
+{% if IOReadBandwidthMax|default("") %}
+IOReadBandwidthMax={{ IOReadBandwidthMax }}
+{% endif %}
+{% if IOWriteBandwidthMax|default("") %}
+IOWriteBandwidthMax={{ IOWriteBandwidthMax }}
+{% endif %}
 LimitNOFILE=1000000
 #LimitCORE=infinity
 LimitSTACK=10485760


### PR DESCRIPTION
#563 added `MemoryLimit` to limit memory consumption. Here a `CPUQuota` setting is added to limit CPU usage, and `IOReadBandwidthMax` and `IOWriteBandwidthMax` settings are added to limit disk IO bandwidth.

These settings are all optional argument applyed to hosts, and have the same value syntax as documented in the `SYSTEMD.RESOURCE-CONTROL(5)` man page