### PR TITLE
Pre check tidb-servers version in parallel

### DIFF
--- a/excessive_rolling_update.yml
+++ b/excessive_rolling_update.yml
@@ -41,7 +41,6 @@
 - name: Pre-check for rolling update
   hosts: tidb_servers
   any_errors_fatal: true
-  serial: 1
   tags:
     - always
   tasks:

--- a/rolling_update.yml
+++ b/rolling_update.yml
@@ -41,7 +41,6 @@
 - name: Pre-check for rolling update
   hosts: tidb_servers
   any_errors_fatal: true
-  serial: 1
   tags:
     - always
   tasks:


### PR DESCRIPTION
In the detection phase of the rolling update, just check the tidb-server version, maybe it should be checked in parallel.