### PR TITLE
Update Readme URL to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ You can use the TiDB-Ansible configuration file to set up the cluster topology, 
 
 ## Tutorial
 
-- [English](https://github.com/pingcap/docs/blob/master/op-guide/ansible-deployment.md)
-- [简体中文](https://github.com/pingcap/docs-cn/blob/master/op-guide/ansible-deployment.md)
+- [English](https://pingcap.com/docs/dev/how-to/deploy/orchestrated/ansible/)
+- [简体中文](https://pingcap.com/docs-cn/op-guide/ansible-deployment/)
 
 ## License
 TiDB-Ansible is under the Apache 2.0 license. 


### PR DESCRIPTION
Fixes a broken link (the file was renamed yesterday for English). There are redirects for accessing docs via web, but not via Git.

Changed both docs and docs-cn, since docs-cn will rename the file soon.