### PR TITLE
update Pump-cluster default value of gc in config

### DIFF
--- a/conf/pump-cluster.yml
+++ b/conf/pump-cluster.yml
@@ -4,7 +4,7 @@
 global:
   # a integer value to control expiry date of the binlog data, indicates for how long (in days) the binlog data would be stored. 
   # must bigger than 0
-  # gc: 5
+  # gc: 7
 
   # number of seconds between heartbeat ticks (in 2 seconds)
   # heartbeat-interval: 2

--- a/roles/pump_cluster/vars/default.yml
+++ b/roles/pump_cluster/vars/default.yml
@@ -4,7 +4,7 @@
 global:
   # a integer value to control expiry date of the binlog data, indicates for how long (in days) the binlog data would be stored. 
   # must bigger than 0
-  gc: 5
+  gc: 7
 
   # number of seconds between heartbeat ticks (in 2 seconds)
   heartbeat-interval: 2


### PR DESCRIPTION
### PR background
When reviewing the TiDB-Binlog doc, we found the there is an difference between the pump config file and ansible pump config file. 

1. the gc in ansible pump config is default by 5. 
https://github.com/pingcap/tidb-ansible/blob/master/conf/pump-cluster.yml

2. the gc in pump config is default by 7.
https://github.com/pingcap/tidb-binlog/blob/master/cmd/pump/pump.toml

Tools think it will be better if unify them to 7.

### What i did in this PR
i changed the gc default value in ansible from 5 to 7. 