### PR TITLE
binlog.json: Fix node board and `sql query time`

### DIFF
--- a/scripts/binlog.json
+++ b/scripts/binlog.json
@@ -1363,7 +1363,7 @@
               "expr": "histogram_quantile(0.99, rate(binlog_drainer_query_duration_time_bucket{instance = \"$drainer_instance\"}[1m]))",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{job}}",
+              "legendFormat": "{{type}}",
               "metric": "binlog_drainer_txn_duration_time_bucket",
               "refId": "A",
               "step": 2
@@ -1697,7 +1697,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "go_goroutines{job=\"binlog\"}",
+              "expr": "go_goroutines{job=~\"binlog|pump|drainer\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",
@@ -1780,7 +1780,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "go_memstats_heap_inuse_bytes{job=\"binlog\"}",
+              "expr": "go_memstats_heap_inuse_bytes{job=~\"binlog|pump|drainer\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",


### PR DESCRIPTION
- query using `job=binlog`, but it's pump and drainer
<img width="1358" alt="Screen Shot 2019-05-15 at 4 10 07 PM" src="https://user-images.githubusercontent.com/1681864/58158170-7a532800-7cac-11e9-8e15-3785b5244e6c.png">

- Should display type but not job name


<img width="708" alt="Screen Shot 2019-05-15 at 4 10 16 PM" src="https://user-images.githubusercontent.com/1681864/58158173-7b845500-7cac-11e9-8df9-82e551fb6fc9.png">
