### PR TITLE
make sure the first region is replicated before starting tidb

### DIFF
--- a/inventory.ini
+++ b/inventory.ini
@@ -92,6 +92,9 @@ enable_tls = False
 # KV mode
 deploy_without_tidb = False
 
+# wait for region replication complete before start tidb-server.
+wait_replication = True
+
 # Optional: Set if you already have a alertmanager server.
 # Format: alertmanager_host:alertmanager_port
 alertmanager_target = ""

--- a/start.yml
+++ b/start.yml
@@ -309,7 +309,7 @@
         return content: yes
         body_format: json
       register: cluster_status_http
-      until: cluster_status_https.json.is_initialized is defined and cluster_status_https.json.is_initialized == true
+      until: cluster_status_http.json.is_initialized is defined and cluster_status_http.json.is_initialized == true
       retries: 20
       delay: 10
       when:

--- a/start.yml
+++ b/start.yml
@@ -247,7 +247,6 @@
       delay: 5
       when: enable_tls|default(false)
 
-
 - hosts: tikv_servers
   tags:
     - tikv
@@ -302,6 +301,38 @@
       debug:
         msg: "tikv binary or docker pid: {{ new_tikv_pid.stdout }}"
 
+- hosts: pd_servers[0]
+  tasks:
+    - name: wait for region replication complete
+      uri: 
+        url: "http://{{ ansible_host }}:{{ pd_client_port }}/pd/api/v1/cluster/status"
+        return content: yes
+        body_format: json
+      register: cluster_status_http
+      until: cluster_status_http.json.is_initialized is undefined or cluster_status_http.json.is_initialized == true
+      retries: 20
+      delay: 10
+      when:
+        - not enable_tls|default(false)
+        - wait_replication|default(false)
+
+- hosts: pd_servers[0]
+  tasks:
+    - name: wait for region replication complete with tls enabled
+      uri:
+        url: "https://{{ ansible_host }}:{{ pd_client_port }}/pd/api/v1/cluster/status"
+        validate_certs: no
+        client_cert: "{{ pd_cert_dir }}/pd-server-{{ ansible_host }}.pem"
+        client_key: "{{ pd_cert_dir }}/pd-server-{{ ansible_host }}-key.pem"
+        return content: yes
+        body_format: json
+      register: cluster_status_https
+      until: cluster_status_https.json.is_initialized is undefined or cluster_status_https.json.is_initialized == true
+      retries: 20
+      delay: 10
+      when:
+        - enable_tls|default(false)
+        - wait_replication|default(false)
 
 - hosts: pump_servers
   tags:

--- a/start.yml
+++ b/start.yml
@@ -309,7 +309,7 @@
         return content: yes
         body_format: json
       register: cluster_status_http
-      until: cluster_status_http.json.is_initialized is undefined or cluster_status_http.json.is_initialized == true
+      until: cluster_status_https.json.is_initialized is defined and cluster_status_https.json.is_initialized == true
       retries: 20
       delay: 10
       when:
@@ -327,7 +327,7 @@
         return content: yes
         body_format: json
       register: cluster_status_https
-      until: cluster_status_https.json.is_initialized is undefined or cluster_status_https.json.is_initialized == true
+      until: cluster_status_https.json.is_initialized is defined and cluster_status_https.json.is_initialized == true
       retries: 20
       delay: 10
       when:


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

Take advantage of the new `is_initialized` flag (https://github.com/pingcap/pd/pull/1555) in PD's cluster status API to avoid starting tidb-server before the first region having enough replicas.

I have tested following cases:

- `ansible-playbook start.yml` with 3 tikv-servers. It retries 2~3 times to wait for making up replicas.
- `ansible-playbook start.yml` with 2 tikv-servers. It retries 20 times then report an error.
- `ansible-playbook start.yml` with 2 tikv-servers and an old PD (which does not have the flag). The wait process is skipped.

Note: Previously, it was allowed to run a cluster configured as `max-replicas=3` but only has 1 tikv-server. After this PR it will be disallowed. User need to either set `max-replicas` to 1 or set `wait_replication` to `False`.