### PR TITLE
fix GC tasks legend format in tikv metrics and broken layout in TiKV's dashboard

### DIFF
--- a/scripts/tikv_details.json
+++ b/scripts/tikv_details.json
@@ -10961,6 +10961,7 @@
               "expr": "sum(rate(tikv_gc_worker_too_busy{instance=~\"$instance\"}[1m]))",
               "format": "time_series",
               "intervalFactor": 2,
+              "legendFormat": "gcworker-too-busy",
               "refId": "D"
             }
           ],

--- a/scripts/tikv_details.json
+++ b/scripts/tikv_details.json
@@ -11603,7 +11603,7 @@
             "x": 12,
             "y": 47
           },
-          "id": 2820,
+          "id": 2823,
           "legend": {
             "alignAsTable": true,
             "avg": false,


### PR DESCRIPTION
In TiKV's grafana panel, the metric gcworker-too-busy in "GC tasks" lost its legend format, so it shows "{}" in its legend. This PR fixes it.