### PR TITLE
scrips: add parse & compile duration to tidb grafana (#795)

### DIFF
--- a/scripts/tidb.json
+++ b/scripts/tidb.json
@@ -2372,7 +2372,209 @@
               "show": true
             }
           ]
-        }
+        },
+	{
+	  "type": "graph",
+	  "title": "Compile Duration",
+	  "gridPos": {
+	    "x": 0,
+	    "y": 13,
+	    "w": 12,
+	    "h": 8
+	  },
+	  "aliasColors": {},
+	  "bars": false,
+	  "dashLength": 10,
+	  "dashes": false,
+	  "datasource": "${DS_TEST-CLUSTER}",
+	  "decimals": null,
+	  "editable": true,
+	  "error": false,
+	  "fill": 1,
+	  "grid": {},
+	  "id": 154,
+	  "legend": {
+	    "alignAsTable": true,
+	    "avg": true,
+	    "current": true,
+	    "hideEmpty": true,
+	    "hideZero": true,
+	    "max": true,
+	    "min": false,
+	    "rightSide": true,
+	    "show": true,
+	    "sort": null,
+	    "sortDesc": null,
+	    "total": false,
+	    "values": true
+	  },
+	  "lines": true,
+	  "linewidth": 1,
+	  "links": [],
+	  "nullPointMode": "null as zero",
+	  "percentage": false,
+	  "pointradius": 5,
+	  "points": false,
+	  "renderer": "flot",
+	  "seriesOverrides": [],
+	  "spaceLength": 10,
+	  "stack": false,
+	  "steppedLine": false,
+	  "targets": [
+	    {
+	      "expr": "histogram_quantile(0.95, sum(rate(tidb_session_compile_duration_seconds_bucket[1m])) by (le, instance))",
+	      "format": "time_series",
+	      "intervalFactor": 2,
+	      "legendFormat": "{{instance}}",
+	      "refId": "A",
+	      "step": 30,
+	      "instant": false
+	    }
+	  ],
+	  "thresholds": [],
+	  "timeFrom": null,
+	  "timeRegions": [],
+	  "timeShift": null,
+	  "tooltip": {
+	    "msResolution": false,
+	    "shared": true,
+	    "sort": 0,
+	    "value_type": "cumulative"
+	  },
+	  "xaxis": {
+	    "buckets": null,
+	    "mode": "time",
+	    "name": null,
+	    "show": true,
+	    "values": []
+	  },
+	  "yaxes": [
+	    {
+	      "format": "s",
+	      "label": null,
+	      "logBase": 1,
+	      "max": null,
+	      "min": "0",
+	      "show": true,
+	      "decimals": null
+	    },
+	    {
+	      "format": "short",
+	      "label": null,
+	      "logBase": 1,
+	      "max": null,
+	      "min": null,
+	      "show": false
+	    }
+	  ],
+	  "yaxis": {
+	    "align": false,
+	    "alignLevel": null
+	  },
+	  "description": "The time cost of building the query plan",
+	  "interval": ""
+	},
+	{
+	  "type": "graph",
+	  "title": "Parse Duration",
+	  "gridPos": {
+	    "x": 12,
+	    "y": 13,
+	    "w": 12,
+	    "h": 8
+	  },
+	  "aliasColors": {},
+	  "bars": false,
+	  "dashLength": 10,
+	  "dashes": false,
+	  "datasource": "${DS_TEST-CLUSTER}",
+	  "decimals": null,
+	  "editable": true,
+	  "error": false,
+	  "fill": 1,
+	  "grid": {},
+	  "id": 156,
+	  "legend": {
+	    "alignAsTable": true,
+	    "avg": true,
+	    "current": true,
+	    "hideEmpty": true,
+	    "hideZero": true,
+	    "max": true,
+	    "min": false,
+	    "rightSide": true,
+	    "show": true,
+	    "sort": null,
+	    "sortDesc": null,
+	    "total": false,
+	    "values": true
+	  },
+	  "lines": true,
+	  "linewidth": 1,
+	  "links": [],
+	  "nullPointMode": "null as zero",
+	  "percentage": false,
+	  "pointradius": 5,
+	  "points": false,
+	  "renderer": "flot",
+	  "seriesOverrides": [],
+	  "spaceLength": 10,
+	  "stack": false,
+	  "steppedLine": false,
+	  "targets": [
+	    {
+	      "expr": "histogram_quantile(0.95, sum(rate(tidb_session_parse_duration_seconds_bucket[1m])) by (le, instance))",
+	      "format": "time_series",
+	      "intervalFactor": 2,
+	      "legendFormat": "{{instance}}",
+	      "refId": "A",
+	      "step": 30,
+	      "instant": false
+	    }
+	  ],
+	  "thresholds": [],
+	  "timeFrom": null,
+	  "timeRegions": [],
+	  "timeShift": null,
+	  "tooltip": {
+	    "msResolution": false,
+	    "shared": true,
+	    "sort": 0,
+	    "value_type": "cumulative"
+	  },
+	  "xaxis": {
+	    "buckets": null,
+	    "mode": "time",
+	    "name": null,
+	    "show": true,
+	    "values": []
+	  },
+	  "yaxes": [
+	    {
+	      "format": "s",
+	      "label": null,
+	      "logBase": 1,
+	      "max": null,
+	      "min": "0",
+	      "show": true,
+	      "decimals": null
+	    },
+	    {
+	      "format": "short",
+	      "label": null,
+	      "logBase": 1,
+	      "max": null,
+	      "min": null,
+	      "show": false
+	    }
+	  ],
+	  "yaxis": {
+	    "align": false,
+	    "alignLevel": null
+	  },
+	  "description": "The time cost of parsing SQL to AST",
+	  "interval": ""
+	}
       ],
       "repeat": null,
       "repeatIteration": null,

--- a/scripts/tidb.json
+++ b/scripts/tidb.json
@@ -2197,7 +2197,7 @@
     },
     {
       "collapse": true,
-      "height": 301,
+      "height": 293,
       "panels": [
         {
           "aliasColors": {},
@@ -2374,25 +2374,25 @@
           ]
         },
         {
-          "type": "graph",
-          "title": "Compile Duration",
-          "gridPos": {
-            "x": 0,
-            "y": 13,
-            "w": 12,
-            "h": 8
-          },
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "decimals": null,
+          "description": "The time cost of building the query plan",
           "editable": true,
           "error": false,
           "fill": 1,
           "grid": {},
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 13
+          },
           "id": 154,
+          "interval": "",
           "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -2418,29 +2418,32 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
               "expr": "histogram_quantile(0.95, sum(rate(tidb_session_compile_duration_seconds_bucket[1m])) by (le, instance))",
               "format": "time_series",
+              "instant": false,
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",
               "refId": "A",
-              "step": 30,
-              "instant": false
+              "step": 30
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
+          "title": "Compile Duration",
           "tooltip": {
             "msResolution": false,
             "shared": true,
             "sort": 0,
             "value_type": "cumulative"
           },
+          "type": "graph",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2450,13 +2453,13 @@
           },
           "yaxes": [
             {
+              "decimals": null,
               "format": "s",
               "label": null,
               "logBase": 1,
               "max": null,
               "min": "0",
-              "show": true,
-              "decimals": null
+              "show": true
             },
             {
               "format": "short",
@@ -2470,30 +2473,28 @@
           "yaxis": {
             "align": false,
             "alignLevel": null
-          },
-          "description": "The time cost of building the query plan",
-          "interval": ""
+          }
         },
         {
-          "type": "graph",
-          "title": "Parse Duration",
-          "gridPos": {
-            "x": 12,
-            "y": 13,
-            "w": 12,
-            "h": 8
-          },
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "decimals": null,
+          "description": "The time cost of parsing SQL to AST",
           "editable": true,
           "error": false,
           "fill": 1,
           "grid": {},
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
           "id": 156,
+          "interval": "",
           "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -2519,29 +2520,32 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
               "expr": "histogram_quantile(0.95, sum(rate(tidb_session_parse_duration_seconds_bucket[1m])) by (le, instance))",
               "format": "time_series",
+              "instant": false,
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",
               "refId": "A",
-              "step": 30,
-              "instant": false
+              "step": 30
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
+          "title": "Parse Duration",
           "tooltip": {
             "msResolution": false,
             "shared": true,
             "sort": 0,
             "value_type": "cumulative"
           },
+          "type": "graph",
           "xaxis": {
             "buckets": null,
             "mode": "time",
@@ -2551,13 +2555,13 @@
           },
           "yaxes": [
             {
+              "decimals": null,
               "format": "s",
               "label": null,
               "logBase": 1,
               "max": null,
               "min": "0",
-              "show": true,
-              "decimals": null
+              "show": true
             },
             {
               "format": "short",
@@ -2571,9 +2575,7 @@
           "yaxis": {
             "align": false,
             "alignLevel": null
-          },
-          "description": "The time cost of parsing SQL to AST",
-          "interval": ""
+          }
         }
       ],
       "repeat": null,
@@ -7231,6 +7233,6 @@
     ]
   },
   "timezone": "browser",
-  "title": "Test-Cluster-TiDB",
-  "version": 3
+  "title": "Test-Cluster-TiDB1",
+  "version": 2
 }

--- a/scripts/tidb.json
+++ b/scripts/tidb.json
@@ -2373,208 +2373,208 @@
             }
           ]
         },
-	{
-	  "type": "graph",
-	  "title": "Compile Duration",
-	  "gridPos": {
-	    "x": 0,
-	    "y": 13,
-	    "w": 12,
-	    "h": 8
-	  },
-	  "aliasColors": {},
-	  "bars": false,
-	  "dashLength": 10,
-	  "dashes": false,
-	  "datasource": "${DS_TEST-CLUSTER}",
-	  "decimals": null,
-	  "editable": true,
-	  "error": false,
-	  "fill": 1,
-	  "grid": {},
-	  "id": 154,
-	  "legend": {
-	    "alignAsTable": true,
-	    "avg": true,
-	    "current": true,
-	    "hideEmpty": true,
-	    "hideZero": true,
-	    "max": true,
-	    "min": false,
-	    "rightSide": true,
-	    "show": true,
-	    "sort": null,
-	    "sortDesc": null,
-	    "total": false,
-	    "values": true
-	  },
-	  "lines": true,
-	  "linewidth": 1,
-	  "links": [],
-	  "nullPointMode": "null as zero",
-	  "percentage": false,
-	  "pointradius": 5,
-	  "points": false,
-	  "renderer": "flot",
-	  "seriesOverrides": [],
-	  "spaceLength": 10,
-	  "stack": false,
-	  "steppedLine": false,
-	  "targets": [
-	    {
-	      "expr": "histogram_quantile(0.95, sum(rate(tidb_session_compile_duration_seconds_bucket[1m])) by (le, instance))",
-	      "format": "time_series",
-	      "intervalFactor": 2,
-	      "legendFormat": "{{instance}}",
-	      "refId": "A",
-	      "step": 30,
-	      "instant": false
-	    }
-	  ],
-	  "thresholds": [],
-	  "timeFrom": null,
-	  "timeRegions": [],
-	  "timeShift": null,
-	  "tooltip": {
-	    "msResolution": false,
-	    "shared": true,
-	    "sort": 0,
-	    "value_type": "cumulative"
-	  },
-	  "xaxis": {
-	    "buckets": null,
-	    "mode": "time",
-	    "name": null,
-	    "show": true,
-	    "values": []
-	  },
-	  "yaxes": [
-	    {
-	      "format": "s",
-	      "label": null,
-	      "logBase": 1,
-	      "max": null,
-	      "min": "0",
-	      "show": true,
-	      "decimals": null
-	    },
-	    {
-	      "format": "short",
-	      "label": null,
-	      "logBase": 1,
-	      "max": null,
-	      "min": null,
-	      "show": false
-	    }
-	  ],
-	  "yaxis": {
-	    "align": false,
-	    "alignLevel": null
-	  },
-	  "description": "The time cost of building the query plan",
-	  "interval": ""
-	},
-	{
-	  "type": "graph",
-	  "title": "Parse Duration",
-	  "gridPos": {
-	    "x": 12,
-	    "y": 13,
-	    "w": 12,
-	    "h": 8
-	  },
-	  "aliasColors": {},
-	  "bars": false,
-	  "dashLength": 10,
-	  "dashes": false,
-	  "datasource": "${DS_TEST-CLUSTER}",
-	  "decimals": null,
-	  "editable": true,
-	  "error": false,
-	  "fill": 1,
-	  "grid": {},
-	  "id": 156,
-	  "legend": {
-	    "alignAsTable": true,
-	    "avg": true,
-	    "current": true,
-	    "hideEmpty": true,
-	    "hideZero": true,
-	    "max": true,
-	    "min": false,
-	    "rightSide": true,
-	    "show": true,
-	    "sort": null,
-	    "sortDesc": null,
-	    "total": false,
-	    "values": true
-	  },
-	  "lines": true,
-	  "linewidth": 1,
-	  "links": [],
-	  "nullPointMode": "null as zero",
-	  "percentage": false,
-	  "pointradius": 5,
-	  "points": false,
-	  "renderer": "flot",
-	  "seriesOverrides": [],
-	  "spaceLength": 10,
-	  "stack": false,
-	  "steppedLine": false,
-	  "targets": [
-	    {
-	      "expr": "histogram_quantile(0.95, sum(rate(tidb_session_parse_duration_seconds_bucket[1m])) by (le, instance))",
-	      "format": "time_series",
-	      "intervalFactor": 2,
-	      "legendFormat": "{{instance}}",
-	      "refId": "A",
-	      "step": 30,
-	      "instant": false
-	    }
-	  ],
-	  "thresholds": [],
-	  "timeFrom": null,
-	  "timeRegions": [],
-	  "timeShift": null,
-	  "tooltip": {
-	    "msResolution": false,
-	    "shared": true,
-	    "sort": 0,
-	    "value_type": "cumulative"
-	  },
-	  "xaxis": {
-	    "buckets": null,
-	    "mode": "time",
-	    "name": null,
-	    "show": true,
-	    "values": []
-	  },
-	  "yaxes": [
-	    {
-	      "format": "s",
-	      "label": null,
-	      "logBase": 1,
-	      "max": null,
-	      "min": "0",
-	      "show": true,
-	      "decimals": null
-	    },
-	    {
-	      "format": "short",
-	      "label": null,
-	      "logBase": 1,
-	      "max": null,
-	      "min": null,
-	      "show": false
-	    }
-	  ],
-	  "yaxis": {
-	    "align": false,
-	    "alignLevel": null
-	  },
-	  "description": "The time cost of parsing SQL to AST",
-	  "interval": ""
-	}
+        {
+          "type": "graph",
+          "title": "Compile Duration",
+          "gridPos": {
+            "x": 0,
+            "y": 13,
+            "w": 12,
+            "h": 8
+          },
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "decimals": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {},
+          "id": 154,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sort": null,
+            "sortDesc": null,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(tidb_session_compile_duration_seconds_bucket[1m])) by (le, instance))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}",
+              "refId": "A",
+              "step": 30,
+              "instant": false
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true,
+              "decimals": null
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          },
+          "description": "The time cost of building the query plan",
+          "interval": ""
+        },
+        {
+          "type": "graph",
+          "title": "Parse Duration",
+          "gridPos": {
+            "x": 12,
+            "y": 13,
+            "w": 12,
+            "h": 8
+          },
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "decimals": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {},
+          "id": 156,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sort": null,
+            "sortDesc": null,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(tidb_session_parse_duration_seconds_bucket[1m])) by (le, instance))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}",
+              "refId": "A",
+              "step": 30,
+              "instant": false
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true,
+              "decimals": null
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          },
+          "description": "The time cost of parsing SQL to AST",
+          "interval": ""
+        }
       ],
       "repeat": null,
       "repeatIteration": null,


### PR DESCRIPTION
Cherry-pick parse & compile to release 2.1 #795 .