### PR TITLE
script: update TSO WAIT DURATION tidb metrics

### DIFF
--- a/scripts/tidb.json
+++ b/scripts/tidb.json
@@ -5800,7 +5800,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.999, sum(rate(pd_client_cmd_handle_cmds_duration_seconds_bucket{type=\"tso\"}[1m])) by (le))",
+              "expr": "histogram_quantile(0.999, sum(rate(pd_client_cmd_handle_cmds_duration_seconds_bucket{type=\"wait\"}[1m])) by (le))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "999",
@@ -5808,14 +5808,14 @@
               "step": 10
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(pd_client_cmd_handle_cmds_duration_seconds_bucket{type=\"tso\"}[1m])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(pd_client_cmd_handle_cmds_duration_seconds_bucket{type=\"wait\"}[1m])) by (le))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "99",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.90, sum(rate(pd_client_cmd_handle_cmds_duration_seconds_bucket{type=\"tso\"}[1m])) by (le))",
+              "expr": "histogram_quantile(0.90, sum(rate(pd_client_cmd_handle_cmds_duration_seconds_bucket{type=\"wait\"}[1m])) by (le))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "90",


### PR DESCRIPTION
I've changed the meaning of TSO WAIT DURATION:
https://github.com/pingcap/pd/pull/1626

Now, this commit updates the grafana:
http://172.16.5.34:34125/d/000000011/yusp-cluster-tidb?orgId=1&refresh=30s&from=now-1h&to=now

![image](https://user-images.githubusercontent.com/1420062/61037102-ff310700-a3fc-11e9-9f20-9d196bf197b7.png)
