### PR TITLE
change tispark jar name

### DIFF
--- a/roles/local/tasks/binary_deployment.yml
+++ b/roles/local/tasks/binary_deployment.yml
@@ -81,7 +81,7 @@
 
 - name: cp tispark
   shell: >
-    cp -v {{ downloads_dir }}/core/target/tispark-core-*-SNAPSHOT-jar-with-dependencies.jar "{{ resources_dir }}/bin/tispark-SNAPSHOT-jar-with-dependencies.jar"
+    cp -v {{ downloads_dir }}/assembly/target/tispark-assembly-*-SNAPSHOT.jar "{{ resources_dir }}/bin/tispark-assembly-SNAPSHOT.jar"
   when: not deploy_without_tidb|default(false)
 
 - name: cp tispark-sample-data

--- a/roles/local/templates/binary_packages.yml.j2
+++ b/roles/local/templates/binary_packages.yml.j2
@@ -50,7 +50,7 @@ tispark_packages:
     checksum: "sha256:6246b20d95c7596a29fb26d5b50a3ae3163a35915bec6c515a8e183383bedc43"
   - name: tispark-latest.tar.gz
     version: latest
-    url: http://download.pingcap.org/tispark-latest-linux-amd64.tar.gz
+    url: http://download.pingcap.org/tispark-assembly-latest-linux-amd64.tar.gz
   - name: tispark-sample-data.tar.gz
     version: latest
     url: http://download.pingcap.org/tispark-sample-data.tar.gz

--- a/roles/tispark/tasks/main.yml
+++ b/roles/tispark/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: deploy tispark
   copy:
-    src: "{{ resources_dir }}/bin/tispark-SNAPSHOT-jar-with-dependencies.jar"
+    src: "{{ resources_dir }}/bin/tispark-assembly-SNAPSHOT.jar"
     dest: "{{ deploy_dir }}/spark/jars/"
 
 - name: load customized spark_env


### PR DESCRIPTION
because of this issue pingcap/tispark#933

tispark jar name changed from `tispark-core-*-SNAPSHOT-jar-with-dependencies.jar` -> `tispark-assembly-*-SNAPSHOT.jar`