### PR TITLE
tispark use 2.1.1 instead of master branch

### DIFF
--- a/roles/local/tasks/binary_deployment.yml
+++ b/roles/local/tasks/binary_deployment.yml
@@ -55,13 +55,6 @@
     warn: no
   with_items: "{{ third_party_packages }}"
 
-- name: unarchive tispark
-  shell: tar xzf tispark-latest.tar.gz
-  args:
-    chdir: "{{ downloads_dir }}"
-    warn: no
-  when: not deploy_without_tidb|default(false)
-
 - name: unarchive tispark-sample-data
   shell: ls -1 tispark-sample-data.tar.gz | xargs -n1 tar xzf
   args:
@@ -81,7 +74,7 @@
 
 - name: cp tispark
   shell: >
-    cp -v {{ downloads_dir }}/core/target/tispark-core-*-SNAPSHOT-jar-with-dependencies.jar "{{ resources_dir }}/bin/tispark-SNAPSHOT-jar-with-dependencies.jar"
+    cp -v {{ downloads_dir }}/tispark-core-2.1.1-spark_2.3-jar-with-dependencies.jar "{{ resources_dir }}/bin/tispark-core-2.1.1-spark_2.3-jar-with-dependencies.jar"
   when: not deploy_without_tidb|default(false)
 
 - name: cp tispark-sample-data

--- a/roles/local/templates/binary_packages.yml.j2
+++ b/roles/local/templates/binary_packages.yml.j2
@@ -48,9 +48,9 @@ tispark_packages:
     version: 2.3.2
     url: http://download.pingcap.org/spark-2.3.2-bin-hadoop2.7.tgz
     checksum: "sha256:6246b20d95c7596a29fb26d5b50a3ae3163a35915bec6c515a8e183383bedc43"
-  - name: tispark-latest.tar.gz
-    version: latest
-    url: http://download.pingcap.org/tispark-latest-linux-amd64.tar.gz
+  - name: tispark-core-2.1.1-spark_2.3-jar-with-dependencies.jar
+    version: 2.1.1
+    url: https://github.com/pingcap/tispark/releases/download/v2.1.1/tispark-core-2.1.1-spark_2.3-jar-with-dependencies.jar
   - name: tispark-sample-data.tar.gz
     version: latest
     url: http://download.pingcap.org/tispark-sample-data.tar.gz

--- a/roles/tispark/tasks/main.yml
+++ b/roles/tispark/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: deploy tispark
   copy:
-    src: "{{ resources_dir }}/bin/tispark-SNAPSHOT-jar-with-dependencies.jar"
+    src: "{{ resources_dir }}/bin/tispark-core-2.1.1-spark_2.3-jar-with-dependencies.jar"
     dest: "{{ deploy_dir }}/spark/jars/"
 
 - name: load customized spark_env


### PR DESCRIPTION
cherry-pick https://github.com/pingcap/tidb-ansible/pull/837

release-2.0 should depend on tispark-2.1.1 which is tispark's latest stable release, instead of depend on tispark's master branch.