### PR TITLE
update tikv grafana allocator_stats name

### DIFF
--- a/scripts/tikv_details.json
+++ b/scripts/tikv_details.json
@@ -19091,7 +19091,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "tikv_jemalloc_stats{instance=~\"$instance\"}",
+              "expr": "tikv_allocator_stats{instance=~\"$instance\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -19102,7 +19102,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Jemalloc Stats",
+          "title": "Allocator Stats",
           "tooltip": {
             "shared": true,
             "sort": 0,


### PR DESCRIPTION
https://github.com/tikv/tikv/pull/4411 changed allocator stats name from "jemalloc_stats" to "allocator_stats". Update grafana config accordingly.

Tested by deploy a cluster and check grafana:
<img width="1005" alt="Screen Shot 2019-05-03 at 12 34 08 PM" src="https://user-images.githubusercontent.com/2606959/57161191-c68f0480-6d9f-11e9-87a2-3fd476142050.png">

Signed-off-by: Yi Wu <yiwu@pingcap.com>