### PR TITLE
drainer: add ignore-txn-commit-ts config

### DIFF
--- a/conf/drainer-cluster.toml
+++ b/conf/drainer-cluster.toml
@@ -35,6 +35,9 @@ safe-mode = false
 # valid values are "mysql", "file", "tidb", "flash", "kafka"
 db-type = "mysql"
 
+# ignore syncing the txn with specified commit ts to downstream
+ignore-txn-commit-ts = []
+
 # replicate-do-db priority over replicate-do-table if have same db name
 # and we support regex expression , start with '~' declare use regex expression.
 # replicate-do-db = ["~^b.*","s1"]


### PR DESCRIPTION
### PR Background 
Drainer adds `ignore-txn-commit-ts config` config, this PR adds the config in ansible. 

### Related PR
TiDB Binlog: https://github.com/pingcap/tidb-binlog/pull/685