### PR TITLE
fix pessimistic-txn config of tikv

### DIFF
--- a/conf/tikv.yml
+++ b/conf/tikv.yml
@@ -711,17 +711,14 @@ import:
   ## Stream channel window size, stream will be blocked on channel full.
   # stream-channel-window: 128
 
-pessimistic-txn:
+pessimistic_txn:
   ## Enable pessimistic transaction
   # enabled: true
 
   ## Time to wait in milliseconds before responding to TiDB when pessimistic
-  ## transactions # encounter locks
+  ## transactions encounter locks
   # wait-for-lock-timeout: 3000
 
   ## Time to delay in milliseconds before responding to TiDB when other transactions
   ## release locks that pessimistic transactions are waiting for(0 to disable).
   # wake-up-delay-duration: 1
-
-  ## Interval in milliseconds to check the membership change of deadlock detector.
-  # monitor-membership-interval: 3000

--- a/roles/tikv/templates/tikv.toml.j2
+++ b/roles/tikv/templates/tikv.toml.j2
@@ -102,3 +102,8 @@
 {% for item, value in tikv_conf.import | dictsort -%}
 {{ item }} = {{ value | to_json }}
 {% endfor %}
+
+[pessimistic-txn]
+{% for item, value in tikv_conf.pessimistic_txn | dictsort -%}
+{{ item }} = {{ value | to_json }}
+{% endfor %}

--- a/roles/tikv/vars/default.yml
+++ b/roles/tikv/vars/default.yml
@@ -711,17 +711,14 @@ import:
   ## Stream channel window size, stream will be blocked on channel full.
   # stream-channel-window: 128
 
-pessimistic-txn:
+pessimistic_txn:
   ## Enable pessimistic transaction
   # enabled: true
 
   ## Time to wait in milliseconds before responding to TiDB when pessimistic
-  ## transactions # encounter locks
+  ## transactions encounter locks
   # wait-for-lock-timeout: 3000
 
   ## Time to delay in milliseconds before responding to TiDB when other transactions
   ## release locks that pessimistic transactions are waiting for(0 to disable).
   # wake-up-delay-duration: 1
-
-  ## Interval in milliseconds to check the membership change of deadlock detector.
-  # monitor-membership-interval: 3000


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

* Fix pessimistic-txn config of tikv.
* Remove `monitor-membership-interval` which has removed in https://github.com/tikv/tikv/pull/5028.