### PR TITLE
scripts: support to select an individual store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ fact_files/
 .vagrant/
 *.pyc
 .vscode
+.DS_Store

--- a/scripts/pd.json
+++ b/scripts/pd.json
@@ -2210,7 +2210,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_scheduler_store_status{instance=\"$instance\", namespace=~\"$namespace\", type=\"store_capacity\"}",
+              "expr": "pd_scheduler_store_status{store=~\"$store\", instance=\"$instance\", namespace=~\"$namespace\", type=\"store_capacity\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -2302,7 +2302,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "{instance=\"$instance\", namespace=~\"$namespace\", type=\"store_available\"}",
+              "expr": "{store=~\"$store\", instance=\"$instance\", namespace=~\"$namespace\", type=\"store_available\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{address}}-store-{{store}}",
@@ -2393,7 +2393,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_scheduler_store_status{instance=\"$instance\", namespace=~\"$namespace\", type=\"store_used\"}",
+              "expr": "pd_scheduler_store_status{store=~\"$store\", instance=\"$instance\", namespace=~\"$namespace\", type=\"store_used\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{address}}-store-{{store}}",
@@ -2483,7 +2483,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(pd_scheduler_store_status{instance=\"$instance\", namespace=~\"$namespace\", type=\"store_available\"}) by (address, store) / sum(pd_scheduler_store_status{instance=\"$instance\", namespace=~\"$namespace\", type=\"store_capacity\"}) by (address, store)",
+              "expr": "sum(pd_scheduler_store_status{store=~\"$store\", instance=\"$instance\", namespace=~\"$namespace\", type=\"store_available\"}) by (address, store) / sum(pd_scheduler_store_status{instance=\"$instance\", namespace=~\"$namespace\", type=\"store_capacity\"}) by (address, store)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{address}}-store-{{store}}",
@@ -2573,7 +2573,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(pd_scheduler_store_status{instance=\"$instance\", namespace=~\"$namespace\", type=\"region_size\"}) by (address, store) / sum(pd_scheduler_store_status{instance=\"$instance\", namespace=~\"$namespace\", type=\"store_used\"}) by (address, store) * 2^20",
+              "expr": "sum(pd_scheduler_store_status{store=~\"$store\", instance=\"$instance\", namespace=~\"$namespace\", type=\"region_size\"}) by (address, store) / sum(pd_scheduler_store_status{instance=\"$instance\", namespace=~\"$namespace\", type=\"store_used\"}) by (address, store) * 2^20",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 2,
@@ -2670,7 +2670,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_scheduler_store_status{instance=\"$instance\", namespace=~\"$namespace\", type=\"region_score\"}",
+              "expr": "pd_scheduler_store_status{store=~\"$store\", instance=\"$instance\", namespace=~\"$namespace\", type=\"region_score\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -2777,7 +2777,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_scheduler_store_status{instance=\"$instance\", namespace=~\"$namespace\", type=\"leader_score\"}",
+              "expr": "pd_scheduler_store_status{store=~\"$store\", instance=\"$instance\", namespace=~\"$namespace\", type=\"leader_score\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{address}}-store-{{store}}",
@@ -2879,7 +2879,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_scheduler_store_status{instance=\"$instance\", namespace=~\"$namespace\", type=\"region_size\"}",
+              "expr": "pd_scheduler_store_status{store=~\"$store\", instance=\"$instance\", namespace=~\"$namespace\", type=\"region_size\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{address}}-store-{{store}}",
@@ -2972,7 +2972,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_scheduler_store_status{instance=\"$instance\", namespace=~\"$namespace\", type=\"leader_size\"}",
+              "expr": "pd_scheduler_store_status{store=~\"$store\", instance=\"$instance\", namespace=~\"$namespace\", type=\"leader_size\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{address}}-store-{{store}}",
@@ -3065,7 +3065,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_scheduler_store_status{instance=\"$instance\", namespace=~\"$namespace\", type=\"region_count\"}",
+              "expr": "pd_scheduler_store_status{store=~\"$store\", instance=\"$instance\", namespace=~\"$namespace\", type=\"region_count\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{address}}-store-{{store}}",
@@ -3157,7 +3157,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_scheduler_store_status{instance=\"$instance\", namespace=~\"$namespace\", type=\"leader_count\"}",
+              "expr": "pd_scheduler_store_status{store=~\"$store\", instance=\"$instance\", namespace=~\"$namespace\", type=\"leader_count\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{address}}-store-{{store}}",
@@ -3266,7 +3266,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_hotspot_status{instance=\"$instance\",type=\"hot_write_region_as_leader\"}",
+              "expr": "pd_hotspot_status{store=~\"$store\", instance=\"$instance\", type=\"hot_write_region_as_leader\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{address}}-store-{{store}}",
@@ -3276,6 +3276,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Hot write Region's leader distribution",
           "tooltip": {
@@ -3355,7 +3356,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_hotspot_status{instance=\"$instance\",type=\"hot_write_region_as_peer\"}",
+              "expr": "pd_hotspot_status{store=~\"$store\", instance=\"$instance\", type=\"hot_write_region_as_peer\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{address}}-store-{{store}}",
@@ -3365,6 +3366,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Hot write Region's peer distribution",
           "tooltip": {
@@ -3444,7 +3446,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_hotspot_status{instance=\"$instance\",type=\"total_written_bytes_as_leader\"}",
+              "expr": "pd_hotspot_status{store=~\"$store\", instance=\"$instance\", type=\"total_written_bytes_as_leader\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{address}}-store-{{store}}",
@@ -3455,6 +3457,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Hot write Region's leader written bytes",
           "tooltip": {
@@ -3534,7 +3537,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_hotspot_status{instance=\"$instance\",type=\"total_written_bytes_as_peer\"}",
+              "expr": "pd_hotspot_status{store=~\"$store\", instance=\"$instance\", type=\"total_written_bytes_as_peer\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{address}}-store-{{store}}",
@@ -3544,6 +3547,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Hot Region's peer written bytes",
           "tooltip": {
@@ -3623,7 +3627,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_hotspot_status{instance=\"$instance\",type=\"hot_read_region_as_leader\"}",
+              "expr": "pd_hotspot_status{store=~\"$store\", instance=\"$instance\", type=\"hot_read_region_as_leader\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{address}}-store-{{store}}",
@@ -3633,6 +3637,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Hot read Region's leader distribution",
           "tooltip": {
@@ -3711,7 +3716,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_hotspot_status{instance=\"$instance\",type=\"total_read_bytes_as_leader\"}",
+              "expr": "pd_hotspot_status{store=~\"$store\", instance=\"$instance\", type=\"total_read_bytes_as_leader\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{address}}-store-{{store}}",
@@ -3801,7 +3806,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_scheduler_store_status{type=\"store_write_rate_bytes\"}",
+              "expr": "pd_scheduler_store_status{store=~\"$store\", type=\"store_write_rate_bytes\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{address}}-store-{{store}}",
@@ -3811,6 +3816,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Store write rate bytes",
           "tooltip": {
@@ -3890,7 +3896,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_scheduler_store_status{type=\"store_read_rate_bytes\"}",
+              "expr": "pd_scheduler_store_status{store=~\"$store\", type=\"store_read_rate_bytes\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{address}}-store-{{store}}",
@@ -3900,6 +3906,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Store read rate bytes",
           "tooltip": {
@@ -3978,7 +3985,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_scheduler_store_status{type=\"store_write_rate_keys\"}",
+              "expr": "pd_scheduler_store_status{store=~\"$store\", type=\"store_write_rate_keys\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{address}}-store-{{store}}",
@@ -3988,6 +3995,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Store write rate keys",
           "tooltip": {
@@ -4067,7 +4075,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_scheduler_store_status{type=\"store_read_rate_keys\"}",
+              "expr": "pd_scheduler_store_status{store=~\"$store\", type=\"store_read_rate_keys\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{address}}-store-{{store}}",
@@ -4077,6 +4085,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Store read rate keys",
           "tooltip": {
@@ -4180,6 +4189,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Scheduler is running",
           "tooltip": {
@@ -4258,14 +4268,14 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "- sum(delta(pd_scheduler_balance_leader{address=~\".*out\",instance=\"$instance\", type=\"move_leader\"}[30s])) by (address, store)",
+              "expr": "- sum(delta(pd_scheduler_balance_leader{store=~\"$store\", address=~\".*out\",instance=\"$instance\", type=\"move_leader\"}[30s])) by (address, store)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "store-{{store}}",
               "refId": "A"
             },
             {
-              "expr": "sum(delta(pd_scheduler_balance_leader{address=~\".*in\",instance=\"$instance\", type=\"move_leader\"}[30s])) by (address, store)",
+              "expr": "sum(delta(pd_scheduler_balance_leader{store=~\"$store\", address=~\".*in\",instance=\"$instance\", type=\"move_leader\"}[30s])) by (address, store)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "store-{{store}}",
@@ -4274,6 +4284,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Balance leader movement",
           "tooltip": {
@@ -4353,14 +4364,14 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "-sum(delta(pd_scheduler_balance_region{address=~\".*out\",instance=\"$instance\", type=\"move_peer\"}[1m])) by (address, store)",
+              "expr": "-sum(delta(pd_scheduler_balance_region{store=~\"$store\", address=~\".*out\",instance=\"$instance\", type=\"move_peer\"}[1m])) by (address, store)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "store-{{store}}",
               "refId": "A"
             },
             {
-              "expr": "sum(delta(pd_scheduler_balance_region{address=~\".*in\",instance=\"$instance\", type=\"move_peer\"}[1m])) by (address, store)",
+              "expr": "sum(delta(pd_scheduler_balance_region{store=~\"$store\", address=~\".*in\",instance=\"$instance\", type=\"move_peer\"}[1m])) by (address, store)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "store-{{store}}",
@@ -4369,6 +4380,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Balance Region movement",
           "tooltip": {
@@ -4445,7 +4457,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(delta(pd_scheduler_balance_leader{instance=\"$instance\", type!=\"move_leader\"}[30s])) by (type, address, store)",
+              "expr": "sum(delta(pd_scheduler_balance_leader{store=~\"$store\", instance=\"$instance\", type!=\"move_leader\"}[30s])) by (type, address, store)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{type}}_store-{{store}}",
@@ -4454,6 +4466,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Balance leader event",
           "tooltip": {
@@ -4531,7 +4544,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(delta(pd_scheduler_balance_region{instance=\"$instance\", type!=\"move_peer\"}[30s])) by (type, address, store)",
+              "expr": "sum(delta(pd_scheduler_balance_region{store=~\"$store\", instance=\"$instance\", type!=\"move_peer\"}[30s])) by (type, address, store)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{type}}_store-{{store}}",
@@ -4540,6 +4553,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Balance Region event",
           "tooltip": {
@@ -4629,6 +4643,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Balance leader scheduler",
           "tooltip": {
@@ -4718,6 +4733,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Balance Region scheduler",
           "tooltip": {
@@ -5047,10 +5063,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(delta(pd_schedule_filter{action=\"filter-target\"}[1m])) by (store,type)",
+              "expr": "sum(delta(pd_schedule_filter{store=~\"$store\", action=\"filter-target\"}[1m])) by (store,type)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{store}}-{{type}}",
+              "legendFormat": "store-{{store}}-{{type}}",
               "metric": "pd_scheduler_event_count",
               "refId": "A",
               "step": 4
@@ -5135,10 +5151,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(delta(pd_schedule_filter{action=\"filter-source\"}[1m])) by (store,type)",
+              "expr": "sum(delta(pd_schedule_filter{store=~\"$store\", action=\"filter-source\"}[1m])) by (store,type)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{store}}-{{type}}",
+              "legendFormat": "store-{{store}}-{{type}}",
               "metric": "pd_scheduler_event_count",
               "refId": "A",
               "step": 4
@@ -5311,7 +5327,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "pd_schedule_store_limit{type=\"available\"}",
+              "expr": "pd_schedule_store_limit{store=~\"$store\", type=\"available\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{store}}-avaliable",
@@ -5320,7 +5336,7 @@
               "step": 4
             },
             {
-              "expr": "pd_schedule_store_limit{type=\"take\"}",
+              "expr": "pd_schedule_store_limit{store=~\"$store\", type=\"take\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{store}}-take",
@@ -5931,7 +5947,7 @@
               "logBase": 1,
               "max": null,
               "min": null,
-              "show": true
+              "alignLevel": null
             },
             {
               "format": "short",
@@ -6042,6 +6058,7 @@
             }
           ],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "etcd disk wal fsync rate",
           "tooltip": {
@@ -6074,7 +6091,11 @@
               "min": null,
               "show": true
             }
-          ]
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "aliasColors": {},
@@ -6127,6 +6148,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Raft term",
           "tooltip": {
@@ -6185,7 +6207,7 @@
             "max": false,
             "min": false,
             "rightSide": true,
-            "show": true,
+            "alignLevel": null,
             "total": false,
             "values": true
           },
@@ -6298,6 +6320,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Raft applied index",
           "tooltip": {
@@ -6605,7 +6628,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "round(histogram_quantile(0.99, sum(rate(pd_scheduler_region_heartbeat_latency_seconds_bucket[5m])) by (address, store, le)), 1000)",
+              "expr": "round(histogram_quantile(0.99, sum(rate(pd_scheduler_region_heartbeat_latency_seconds_bucket{store=~\"$store\"}[5m])) by (address, store, le)), 1000)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -6701,7 +6724,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(pd_scheduler_region_heartbeat{type=\"push\",instance=\"$instance\"}[5m])*60) by (address, store, status)",
+              "expr": "sum(rate(pd_scheduler_region_heartbeat{store=~\"$store\", type=\"push\",instance=\"$instance\"}[5m])*60) by (address, store, status)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -6797,7 +6820,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(delta(pd_scheduler_region_heartbeat{instance=\"$instance\", type=\"report\", status=\"ok\"}[1m])) by (address, store)",
+              "expr": "sum(delta(pd_scheduler_region_heartbeat{store=~\"$store\", instance=\"$instance\", type=\"report\", status=\"ok\"}[1m])) by (address, store)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -6893,7 +6916,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(delta(pd_scheduler_region_heartbeat{instance=\"$instance\", type=\"report\", status=\"bind\"}[1m])) by (address, store)",
+              "expr": "sum(delta(pd_scheduler_region_heartbeat{store=~\"$store\", instance=\"$instance\", type=\"report\", status=\"bind\"}[1m])) by (address, store)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -6989,7 +7012,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(delta(pd_scheduler_region_heartbeat{instance=\"$instance\", type=\"report\", status=\"err\"}[1m])) by (address, store)",
+              "expr": "sum(delta(pd_scheduler_region_heartbeat{store=~\"$store\", instance=\"$instance\", type=\"report\", status=\"err\"}[1m])) by (address, store)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -7070,10 +7093,12 @@
           },
           "id": 112,
           "legend": {
+            "alignAsTable": true,
             "avg": false,
             "current": false,
             "max": false,
             "min": false,
+            "rightSide": true,
             "show": true,
             "total": false,
             "values": false
@@ -7101,6 +7126,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Syncer index",
           "tooltip": {
@@ -7150,10 +7176,12 @@
           },
           "id": 113,
           "legend": {
+            "alignAsTable": true,
             "avg": false,
             "current": false,
             "max": false,
             "min": false,
+            "rightSide": true,
             "show": true,
             "total": false,
             "values": false
@@ -7181,8 +7209,9 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
-          "title": "history last index",
+          "title": "History last index",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -7256,11 +7285,33 @@
         "definition": "",
         "hide": 0,
         "includeAll": true,
-        "label": "Namespace",
+        "label": "namespace",
         "multi": false,
         "name": "namespace",
         "options": [],
         "query": "label_values(pd_cluster_status{instance=\"$instance\"}, namespace)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": "${DS_TEST-CLUSTER}",
+        "definition": "label_values(pd_scheduler_store_status, store)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "store",
+        "multi": false,
+        "name": "store",
+        "options": [],
+        "query": "label_values(pd_scheduler_store_status, store)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/scripts/pd.json
+++ b/scripts/pd.json
@@ -7308,7 +7308,7 @@
         "hide": 0,
         "includeAll": true,
         "label": "store",
-        "multi": false,
+        "multi": true,
         "name": "store",
         "options": [],
         "query": "label_values(pd_scheduler_store_status, store)",


### PR DESCRIPTION
This PR supports to select an individual store's metrics.

By setting this variable:
<img width="466" alt="Screen Shot 2019-09-11 at 1 37 50 PM" src="https://user-images.githubusercontent.com/35896542/64670999-9cf69000-d499-11e9-8267-25b02b45c6d0.png">
We can make some metrics more clear. e.g.
<img width="918" alt="Screen Shot 2019-09-11 at 1 37 40 PM" src="https://user-images.githubusercontent.com/35896542/64671000-9e27bd00-d499-11e9-8b82-f0d888924674.png">

