### PR TITLE
tidb: add index speed metric

### DIFF
--- a/scripts/tidb.json
+++ b/scripts/tidb.json
@@ -7922,6 +7922,13 @@
               "intervalFactor": 2,
               "legendFormat": "{{type}}",
               "refId": "A"
+            },
+	    {
+              "expr": "sum(rate(tidb_ddl_add_index_total[1m])) by (type)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{type}}",
+              "refId": "B"
             }
           ],
           "thresholds": [],


### PR DESCRIPTION
Add a metric for DDL add index speed.

Related TiDB PR: https://github.com/pingcap/tidb/pull/12374

![image](https://user-images.githubusercontent.com/26020263/65571668-1ca35500-df98-11e9-8689-032ea4bff47b.png)
