### PR TITLE
Add tidb skip binlog count graph in tidb and binlog dashboards

### DIFF
--- a/scripts/binlog.json
+++ b/scripts/binlog.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1564734492545,
+  "iteration": 1569404109122,
   "links": [],
   "panels": [
     {
@@ -116,6 +116,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Storage Size",
           "tooltip": {
@@ -148,7 +149,11 @@
               "min": null,
               "show": true
             }
-          ]
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "aliasColors": {},
@@ -207,6 +212,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Metadata",
           "tooltip": {
@@ -239,7 +245,11 @@
               "min": null,
               "show": true
             }
-          ]
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "aliasColors": {},
@@ -294,6 +304,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Write Binlog QPS by Instance",
           "tooltip": {
@@ -327,7 +338,11 @@
               "min": null,
               "show": true
             }
-          ]
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "aliasColors": {},
@@ -387,6 +402,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Write Binlog Latency",
           "tooltip": {
@@ -420,7 +436,11 @@
               "min": null,
               "show": true
             }
-          ]
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "aliasColors": {},
@@ -477,6 +497,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Storage Write Binlog Size",
           "tooltip": {
@@ -509,7 +530,11 @@
               "min": null,
               "show": true
             }
-          ]
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "aliasColors": {},
@@ -569,6 +594,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Storage Write Binlog Latency",
           "tooltip": {
@@ -602,7 +628,11 @@
               "min": null,
               "show": true
             }
-          ]
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "aliasColors": {},
@@ -653,6 +683,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Pump Storage Error By Type",
           "tooltip": {
@@ -685,7 +716,11 @@
               "min": null,
               "show": true
             }
-          ]
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "aliasColors": {},
@@ -735,6 +770,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "Query Tikv",
           "tooltip": {
@@ -767,7 +803,98 @@
               "min": null,
               "show": true
             }
-          ]
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 29
+          },
+          "id": 76,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "tidb_server_critical_error_total",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "TiDB Server Skip Binlog Count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
       "repeat": null,
@@ -1998,5 +2125,5 @@
   "timezone": "browser",
   "title": "Test-Cluster-Binlog",
   "uid": "RDdDTFvZz",
-  "version": 2
+  "version": 9
 }

--- a/scripts/tidb.json
+++ b/scripts/tidb.json
@@ -1634,7 +1634,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 60
+            "y": 3
           },
           "id": 184,
           "legend": {
@@ -1735,7 +1735,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 60
+            "y": 3
           },
           "id": 3,
           "legend": {
@@ -1838,7 +1838,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 67
+            "y": 10
           },
           "id": 168,
           "legend": {
@@ -1938,7 +1938,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 67
+            "y": 10
           },
           "id": 8,
           "legend": {
@@ -2042,7 +2042,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 74
+            "y": 17
           },
           "id": 188,
           "legend": {
@@ -2130,7 +2130,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 74
+            "y": 17
           },
           "id": 61,
           "legend": {
@@ -2221,7 +2221,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 81
+            "y": 24
           },
           "id": 183,
           "legend": {
@@ -2318,7 +2318,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 81
+            "y": 24
           },
           "id": 186,
           "legend": {
@@ -2406,7 +2406,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 88
+            "y": 31
           },
           "id": 185,
           "legend": {
@@ -2497,7 +2497,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 88
+            "y": 31
           },
           "id": 187,
           "legend": {
@@ -2594,7 +2594,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 95
+            "y": 38
           },
           "id": 49,
           "legend": {
@@ -2682,7 +2682,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 95
+            "y": 38
           },
           "id": 82,
           "legend": {
@@ -2773,7 +2773,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 102
+            "y": 45
           },
           "id": 165,
           "legend": {
@@ -2877,7 +2877,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 102
+            "y": 45
           },
           "id": 166,
           "legend": {
@@ -2965,7 +2965,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 109
+            "y": 52
           },
           "id": 54,
           "legend": {
@@ -3056,13 +3056,188 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
+          "description": "TiDB instance critical errors count including panic etc",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 52
+          },
+          "id": 191,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "tidb_server_critical_error_total",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Skip Binlog Count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Duration (us) for getting token, it should be small until concurrency limit is reached.",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 59
+          },
+          "id": 111,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(tidb_server_get_token_duration_seconds_bucket[1m])) by (le))",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "99",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Get Token Duration",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "µs",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
           "description": "TiDB processing handshake error count",
           "fill": 1,
           "gridPos": {
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 109
+            "y": 59
           },
           "id": 167,
           "legend": {
@@ -3118,92 +3293,6 @@
           "yaxes": [
             {
               "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_TEST-CLUSTER}",
-          "description": "Duration (us) for getting token, it should be small until concurrency limit is reached.",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 116
-          },
-          "id": 111,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "histogram_quantile(0.99, sum(rate(tidb_server_get_token_duration_seconds_bucket[1m])) by (le))",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "99",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Get Token Duration",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "µs",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -11225,5 +11314,5 @@
   "timezone": "browser",
   "title": "Test-Cluster-TiDB",
   "uid": "000000011",
-  "version": 6
+  "version": 11
 }


### PR DESCRIPTION
Preview:
TiDB:
![image](https://user-images.githubusercontent.com/18556593/65589400-8b45da00-dfbb-11e9-8aed-d11d903f3421.png)
Binlog:
![image](https://user-images.githubusercontent.com/18556593/65589406-8da83400-dfbb-11e9-9fb9-93afbc73a7ec.png)

Signed-off-by: Aylei <rayingecho@gmail.com>