### PR TITLE
Add numa node bind for tidb-server

### DIFF
--- a/roles/tidb/tasks/binary_deployment.yml
+++ b/roles/tidb/tasks/binary_deployment.yml
@@ -8,6 +8,10 @@
   command: mv "{{ tidb_binary.backup_file }}" "{{ backup_dir }}"
   when: tidb_binary.changed and tidb_binary.backup_file is defined
 
+- name: check numa node
+  shell: numactl --hardware | awk 'NR==1{print $2}'
+  register: numa_node_count
+
 - name: create run script
   template:
     src: "{{ item }}_{{ role_name }}_binary.sh.j2"

--- a/roles/tidb/tasks/binary_deployment.yml
+++ b/roles/tidb/tasks/binary_deployment.yml
@@ -8,9 +8,15 @@
   command: mv "{{ tidb_binary.backup_file }}" "{{ backup_dir }}"
   when: tidb_binary.changed and tidb_binary.backup_file is defined
 
+- name: check numactl
+  shell: which numactl
+  ignore_errors: yes
+  register: numactl_info
+
 - name: check numa node
   shell: numactl --hardware | awk 'NR==1{print $2}'
   register: numa_node_count
+  when: not numactl_info.failed
 
 - name: create run script
   template:

--- a/roles/tidb/templates/run_tidb_binary.sh.j2
+++ b/roles/tidb/templates/run_tidb_binary.sh.j2
@@ -9,6 +9,8 @@ DEPLOY_DIR={{ deploy_dir }}
 
 cd "${DEPLOY_DIR}" || exit 1
 
+{% set my_name = hostvars[inventory_hostname].inventory_hostname -%}
+
 {% set my_ip = hostvars[inventory_hostname].ansible_host | default(hostvars[inventory_hostname].inventory_hostname) -%}
 
 {% set all_pd = [] -%}
@@ -19,9 +21,31 @@ cd "${DEPLOY_DIR}" || exit 1
   {% set _ = all_pd.append("%s:%s" % (pd_ip, pd_port)) -%}
 {% endfor -%}
 
+{% set all_node_on_instance = [] -%}
+{% for node in groups.tidb_servers -%}
+  {% set node_ip = hostvars[node].ansible_host | default(hostvars[node].inventory_hostname) -%}
+  {% if node_ip == my_ip -%}
+    {% set _ = all_node_on_instance.append(hostvars[node].inventory_hostname) -%}
+  {% endif -%}
+{% endfor -%}
+
+{% set numaNodeId = [] -%}
+{% if all_node_on_instance | length == numa_node_count.stdout | int -%}
+  {% set set_numa_bind = 'true' -%}
+  {% for inventory_name in all_node_on_instance -%}
+    {% if inventory_name == my_name -%}
+      {% set _ = numaNodeId.append(loop.index0) -%}
+    {% endif -%}
+  {% endfor -%}
+{% endif %}
+
 export TZ={{ timezone }}
 
-exec bin/tidb-server \
+{% if set_numa_bind|default(false) -%}
+  exec numactl --cpunodebind={{ numaNodeId.0 }} --membind={{ numaNodeId.0 }} bin/tidb-server \
+{% else -%}
+  exec bin/tidb-server \
+{% endif %}
     -P {{ tidb_port }} \
     --status="{{ tidb_status_port }}" \
     --advertise-address="{{ my_ip }}" \

--- a/roles/tidb/templates/run_tidb_binary.sh.j2
+++ b/roles/tidb/templates/run_tidb_binary.sh.j2
@@ -29,9 +29,12 @@ cd "${DEPLOY_DIR}" || exit 1
   {% endif -%}
 {% endfor -%}
 
+
 {% set numaNodeId = [] -%}
-{% if all_node_on_instance | length == numa_node_count.stdout | int -%}
-  {% set set_numa_bind = 'true' -%}
+{% if numactl_info.failed -%}
+  {% set set_numa_bind = false -%}
+{% elif all_node_on_instance | length == numa_node_count.stdout | int -%}
+  {% set set_numa_bind = true -%}
   {% for inventory_name in all_node_on_instance -%}
     {% if inventory_name == my_name -%}
       {% set _ = numaNodeId.append(loop.index0) -%}


### PR DESCRIPTION
Note: Need to install `numactl` on each tidb-server machine. If one machine is not installed `numactl`, will deploy tidb-server without bind numa node.
@sykp241095 @superlzs0476 PTAL