### PR TITLE
Consider PD leadership when calculating pd_cluster_status metric

### DIFF
--- a/roles/prometheus/files/pd.rules.yml
+++ b/roles/prometheus/files/pd.rules.yml
@@ -26,12 +26,12 @@ groups:
       summary: PD_etcd_write_disk_latency
 
   - alert: PD_miss_peer_region_count
-    expr: sum( pd_regions_status{type="miss_peer_region_count"} )  > 100
+    expr: (sum(pd_regions_status{type="miss_peer_region_count"}) by (instance)  > 100) and (sum(etcd_server_is_leader) by (instance) > 0)
     for: 1m
     labels:
       env: ENV_LABELS_ENV
       level: critical
-      expr:  sum( pd_regions_status{type="miss_peer_region_count"} )  > 100
+      expr:  (sum(pd_regions_status{type="miss_peer_region_count"}) by (instance)  > 100) and (sum(etcd_server_is_leader) by (instance) > 0)
     annotations:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{ $value }}'
       value: '{{ $value }}'
@@ -86,36 +86,36 @@ groups:
       summary: PD_tidb_handle_requests_duration
 
   - alert: PD_down_peer_region_nums
-    expr: sum ( pd_regions_status{type="down_peer_region_count"} ) > 0
+    expr:  (sum(pd_regions_status{type="down_peer_region_count"}) by (instance)  > 0) and (sum(etcd_server_is_leader) by (instance) > 0)
     for: 1m
     labels:
       env: ENV_LABELS_ENV
       level: warning
-      expr:  sum ( pd_regions_status{type="down_peer_region_count"} ) > 0
+      expr:  (sum(pd_regions_status{type="down_peer_region_count"}) by (instance)  > 0) and (sum(etcd_server_is_leader) by (instance) > 0)
     annotations:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{ $value }}'
       value: '{{ $value }}'
       summary: PD_down_peer_region_nums
 
   - alert: PD_incorrect_namespace_region_count
-    expr: sum ( pd_regions_status{type="incorrect_namespace_region_count"} ) > 100
+    expr: (sum(pd_regions_status{type="incorrect_namespace_region_count"}) by (instance)  > 100) and (sum(etcd_server_is_leader) by (instance) > 0)
     for: 1m
     labels:
       env: ENV_LABELS_ENV
       level: warning
-      expr: sum ( pd_regions_status{type="incorrect_namespace_region_count"} ) > 0
+      expr: (sum(pd_regions_status{type="incorrect_namespace_region_count"}) by (instance)  > 100) and (sum(etcd_server_is_leader) by (instance) > 0)
     annotations:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{ $value }}'
       value: '{{ $value }}'
       summary: PD_incorrect_namespace_region_count
 
   - alert: PD_pending_peer_region_count
-    expr: sum( pd_regions_status{type="pending_peer_region_count"} )  > 100
+    expr: (sum(pd_regions_status{type="pending_peer_region_count"}) by (instance)  > 100) and (sum(etcd_server_is_leader) by (instance) > 0)
     for: 1m
     labels:
       env: ENV_LABELS_ENV
       level: warning
-      expr:  sum( pd_regions_status{type="pending_peer_region_count"} )  > 100
+      expr:  (sum(pd_regions_status{type="pending_peer_region_count"}) by (instance)  > 100) and (sum(etcd_server_is_leader) by (instance) > 0)
     annotations:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{ $value }}'
       value: '{{ $value }}'

--- a/roles/prometheus/files/pd.rules.yml
+++ b/roles/prometheus/files/pd.rules.yml
@@ -2,12 +2,12 @@ groups:
 - name: alert.rules
   rules:
   - alert: PD_cluster_offline_tikv_nums
-    expr: sum ( pd_cluster_status{type="store_down_count"} ) > 0
+    expr: (sum ( pd_cluster_status{type="store_down_count"} ) by (instance) > 0) and (sum(etcd_server_is_leader) by (instance) > 0)
     for: 1m
     labels:
       env: ENV_LABELS_ENV
       level: emergency
-      expr:  sum ( pd_cluster_status{type="store_down_count"} ) > 0
+      expr:  (sum ( pd_cluster_status{type="store_down_count"} ) by (instance) > 0) and (sum(etcd_server_is_leader) by (instance) > 0)
     annotations:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{ $value }}'
       value: '{{ $value }}'
@@ -38,24 +38,24 @@ groups:
       summary: PD_miss_peer_region_count
 
   - alert: PD_cluster_lost_connect_tikv_nums
-    expr: sum ( pd_cluster_status{type="store_disconnected_count"} )   > 0
+    expr: (sum ( pd_cluster_status{type="store_disconnected_count"} ) by (instance) > 0) and (sum(etcd_server_is_leader) by (instance) > 0)
     for: 1m
     labels:
       env: ENV_LABELS_ENV
       level: warning
-      expr:  sum ( pd_cluster_status{type="store_disconnected_count"} )   > 0
+      expr:  (sum ( pd_cluster_status{type="store_disconnected_count"} ) by (instance) > 0) and (sum(etcd_server_is_leader) by (instance) > 0)
     annotations:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{ $value }}'
       value: '{{ $value }}'
       summary: PD_cluster_lost_connect_tikv_nums
 
   - alert: PD_cluster_low_space
-    expr: sum ( pd_cluster_status{type="store_low_space_count"} )  > 0
+    expr: (sum ( pd_cluster_status{type="store_low_space_count"} ) by (instance) > 0) and (sum(etcd_server_is_leader) by (instance) > 0)
     for: 1m
     labels:
       env: ENV_LABELS_ENV
       level: warning
-      expr:  sum ( pd_cluster_status{type="store_low_space_count"} )  > 0
+      expr:  (sum ( pd_cluster_status{type="store_low_space_count"} ) by (instance) > 0) and (sum(etcd_server_is_leader) by (instance) > 0)
     annotations:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{ $value }}'
       value: '{{ $value }}'


### PR DESCRIPTION
close #982 

I did not modify other alerting rules because they won't be affected by stale metrics reported by non-leader instance.

Signed-off-by: Aylei <rayingecho@gmail.com>