### PR TITLE
Partially fix some incorrect raftstore dashboard

### DIFF
--- a/roles/prometheus/files/tikv.rules.yml
+++ b/roles/prometheus/files/tikv.rules.yml
@@ -110,12 +110,12 @@ groups:
       summary: TiKV coprocessor request wait seconds more than 10s
 
   - alert: TiKV_raftstore_thread_cpu_seconds_total
-    expr: sum(rate(tikv_thread_cpu_seconds_total{name=~"raftstore_.*"}[1m])) by (instance, name)  > 1.6
+    expr: sum(rate(tikv_thread_cpu_seconds_total{name=~"raftstore_.*"}[1m])) by (instance)  > 1.6
     for: 1m
     labels:
       env: ENV_LABELS_ENV
       level: critical
-      expr: sum(rate(tikv_thread_cpu_seconds_total{name=~"raftstore_.*"}[1m])) by (instance, name)  > 1.6
+      expr: sum(rate(tikv_thread_cpu_seconds_total{name=~"raftstore_.*"}[1m])) by (instance)  > 1.6
     annotations:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{ $value }}'
       value: '{{ $value }}'

--- a/scripts/overview.json
+++ b/scripts/overview.json
@@ -4234,7 +4234,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(tikv_thread_cpu_seconds_total{name=~\"raftstore_.*\"}[1m])) by (instance, name)",
+              "expr": "sum(rate(tikv_thread_cpu_seconds_total{name=~\"raftstore_.*\"}[1m])) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",


### PR DESCRIPTION
Signed-off-by: Breezewish <me@breeswish.org>

Note: For alert rules, a better way is to check per-thread cpu, because the thread number can vary.