### PR TITLE
Update binlog.json, compatible with version 4.6.3 grafana

### DIFF
--- a/scripts/binlog.json
+++ b/scripts/binlog.json
@@ -14,7 +14,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "6.1.6"
+      "version": "4.6.3"
     },
     {
       "type": "panel",
@@ -51,19 +51,26 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
+  "hideControls": false,
   "id": null,
-  "iteration": 1564734492545,
-  "links": [],
-  "panels": [
+  "links": [
     {
-      "collapsed": true,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 73,
+      "icon": "doc",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Report",
+      "tooltip": "Open a pdf report for the current dashboard",
+      "type": "link",
+      "url": "grafana token"
+    }
+  ],
+  "refresh": "10s",
+  "rows": [
+    {
+      "collapse": true,
+      "height": 269,
       "panels": [
         {
           "aliasColors": {},
@@ -72,12 +79,6 @@
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 1
-          },
           "hideTimeOverride": false,
           "id": 68,
           "legend": {
@@ -102,6 +103,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -157,12 +159,6 @@
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 1
-          },
           "id": 63,
           "legend": {
             "alignAsTable": true,
@@ -187,6 +183,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -251,12 +248,6 @@
           "error": false,
           "fill": 1,
           "grid": {},
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 8
-          },
           "id": 7,
           "legend": {
             "alignAsTable": true,
@@ -279,6 +270,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -339,12 +331,6 @@
           "error": false,
           "fill": 1,
           "grid": {},
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 8
-          },
           "id": 3,
           "legend": {
             "alignAsTable": true,
@@ -367,6 +353,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -429,12 +416,6 @@
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 15
-          },
           "id": 44,
           "legend": {
             "alignAsTable": true,
@@ -457,6 +438,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -521,12 +503,6 @@
           "error": false,
           "fill": 1,
           "grid": {},
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 15
-          },
           "id": 66,
           "legend": {
             "alignAsTable": true,
@@ -549,6 +525,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -611,12 +588,6 @@
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 22
-          },
           "id": 48,
           "legend": {
             "alignAsTable": true,
@@ -639,6 +610,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -694,12 +666,6 @@
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 22
-          },
           "id": 67,
           "legend": {
             "alignAsTable": true,
@@ -722,6 +688,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -771,18 +738,15 @@
         }
       ],
       "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
       "title": "pump",
-      "type": "row"
+      "titleSize": "h6"
     },
     {
-      "collapsed": true,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 1
-      },
-      "id": 74,
+      "collapse": true,
+      "height": 254,
       "panels": [
         {
           "cacheTimeout": null,
@@ -801,12 +765,6 @@
             "show": false,
             "thresholdLabels": false,
             "thresholdMarkers": true
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 8,
-            "x": 0,
-            "y": 23
           },
           "hideTimeOverride": false,
           "id": 70,
@@ -838,6 +796,7 @@
             }
           ],
           "repeat": null,
+          "span": 4,
           "sparkline": {
             "fillColor": "rgba(31, 118, 189, 0.18)",
             "full": false,
@@ -878,12 +837,6 @@
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 16,
-            "x": 8,
-            "y": 23
-          },
           "id": 69,
           "legend": {
             "alignAsTable": true,
@@ -908,6 +861,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 8,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -968,12 +922,6 @@
           "error": false,
           "fill": 1,
           "grid": {},
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 30
-          },
           "id": 62,
           "legend": {
             "alignAsTable": true,
@@ -996,6 +944,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -1056,12 +1005,6 @@
           "error": false,
           "fill": 1,
           "grid": {},
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 30
-          },
           "id": 53,
           "legend": {
             "alignAsTable": true,
@@ -1084,6 +1027,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -1144,12 +1088,6 @@
           "error": false,
           "fill": 1,
           "grid": {},
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 37
-          },
           "id": 58,
           "legend": {
             "alignAsTable": true,
@@ -1172,6 +1110,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -1232,12 +1171,6 @@
           "error": false,
           "fill": 1,
           "grid": {},
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 37
-          },
           "id": 6,
           "legend": {
             "alignAsTable": true,
@@ -1260,6 +1193,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -1320,12 +1254,6 @@
           "error": false,
           "fill": 1,
           "grid": {},
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 44
-          },
           "id": 15,
           "legend": {
             "avg": false,
@@ -1346,6 +1274,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -1402,17 +1331,8 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "editable": true,
-          "error": false,
           "fill": 1,
-          "grid": {},
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 44
-          },
-          "id": 71,
+          "id": 73,
           "legend": {
             "avg": false,
             "current": false,
@@ -1423,7 +1343,7 @@
             "values": false
           },
           "lines": true,
-          "linewidth": 2,
+          "linewidth": 1,
           "links": [],
           "nullPointMode": "connected",
           "percentage": false,
@@ -1432,6 +1352,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -1440,9 +1361,7 @@
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{type}}",
-              "metric": "binlog_drainer_txn_duration_time_bucket",
-              "refId": "A",
-              "step": 2
+              "refId": "A"
             }
           ],
           "thresholds": [],
@@ -1450,10 +1369,9 @@
           "timeShift": null,
           "title": "99% sql query Time",
           "tooltip": {
-            "msResolution": false,
             "shared": true,
             "sort": 0,
-            "value_type": "cumulative"
+            "value_type": "individual"
           },
           "type": "graph",
           "xaxis": {
@@ -1492,12 +1410,6 @@
           "error": false,
           "fill": 1,
           "grid": {},
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 51
-          },
           "id": 55,
           "legend": {
             "alignAsTable": true,
@@ -1520,6 +1432,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -1580,12 +1493,6 @@
           "error": false,
           "fill": 1,
           "grid": {},
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 51
-          },
           "id": 52,
           "legend": {
             "alignAsTable": true,
@@ -1608,6 +1515,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -1666,13 +1574,7 @@
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
           "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 58
-          },
-          "id": 72,
+          "id": 74,
           "legend": {
             "avg": false,
             "current": false,
@@ -1692,6 +1594,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 12,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -1741,18 +1644,15 @@
         }
       ],
       "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
       "title": "drainer",
-      "type": "row"
+      "titleSize": "h6"
     },
     {
-      "collapsed": true,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 2
-      },
-      "id": 75,
+      "collapse": true,
+      "height": "250px",
       "panels": [
         {
           "aliasColors": {},
@@ -1764,12 +1664,6 @@
           "error": false,
           "fill": 1,
           "grid": {},
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 59
-          },
           "id": 9,
           "legend": {
             "alignAsTable": true,
@@ -1792,6 +1686,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -1852,12 +1747,6 @@
           "error": false,
           "fill": 1,
           "grid": {},
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 59
-          },
           "id": 39,
           "legend": {
             "alignAsTable": true,
@@ -1880,6 +1769,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -1932,12 +1822,14 @@
         }
       ],
       "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
       "title": "node",
-      "type": "row"
+      "titleSize": "h6"
     }
   ],
-  "refresh": "10s",
-  "schemaVersion": 18,
+  "schemaVersion": 14,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -1946,7 +1838,6 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_TEST-CLUSTER}",
-        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -1956,7 +1847,6 @@
         "query": "label_values(binlog_drainer_ddl_jobs_total, instance)",
         "refresh": 1,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
@@ -1997,6 +1887,5 @@
   },
   "timezone": "browser",
   "title": "Test-Cluster-Binlog",
-  "uid": "RDdDTFvZz",
-  "version": 2
+  "version": 3
 }


### PR DESCRIPTION
The 6.1.6 version of the dashboard json is not displayed in the Grafana version 4.6.3. Update binlog.json, compatible with version 4.6.3 Grafana.
@july2993 PTAL