### PR TITLE
Update alert rule to work properly when distrubuted gc is enabled

### DIFF
--- a/roles/prometheus/files/tikv.rules.yml
+++ b/roles/prometheus/files/tikv.rules.yml
@@ -14,12 +14,12 @@ groups:
       summary: TiKV memory used too fast
 
   - alert: TiKV_GC_can_not_work
-    expr: sum(increase(tidb_tikvclient_gc_action_result{type="success"}[6h])) < 1
+    expr: sum(increase(tikv_gcworker_gc_tasks_vec{task="gc"}[1d])) < 1
     for: 1m
     labels:
       env: ENV_LABELS_ENV
       level: emergency
-      expr: sum(increase(tidb_tikvclient_gc_action_result{type="success"}[6h])) < 1
+      expr: sum(increase(tikv_gcworker_gc_tasks_vec{task="gc"}[1d])) < 1
     annotations:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{ $value }}'
       value: '{{ $value }}'


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

The alert rule "TiKV GC can not work" checks whether `sum(increase(tidb_tikvclient_gc_action_result{type="success"}[6h])) < 1`. However when distrubuted GC is enabled, the metrics `tidb_tikvclient_gc_action_result`, which counts successful and failed regions of sending GC requests, will not be set. Therefore the alert will be triggered even if GC is running normally. 

This PR changes the expression to `sum(increase(tikv_gcworker_gc_tasks_vec{task="gc"}[1d])) < 1` , which is calculated on TiKV side.

This needs to be cherry-picked to release-3.x branches.