### PR TITLE
remove extra monitor content

### DIFF
--- a/scripts/overview.json
+++ b/scripts/overview.json
@@ -3391,7 +3391,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(tikv_thread_cpu_seconds_total[1m])) by (instance)",
+              "expr": "sum(rate(tikv_thread_cpu_seconds_total{job=\"tikv\"}[2m])) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",

--- a/scripts/overview.json
+++ b/scripts/overview.json
@@ -3391,7 +3391,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(tikv_thread_cpu_seconds_total{job=\"tikv\"}[2m])) by (instance)",
+              "expr": "sum(rate(tikv_thread_cpu_seconds_total{job=\"tikv\"}[1m])) by (instance)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28344969/67182504-f8f5f200-f411-11e9-9473-8ec2e115c26e.png)

Remove tidb3, because it does not belong to tikv.
@rleungx PTAL