### PR TITLE
tune grpc connection default value

### DIFF
--- a/conf/tidb.yml
+++ b/conf/tidb.yml
@@ -124,7 +124,7 @@ opentracing:
 
 tikv_client:
   # Max gRPC connections that will be established with each tikv-server.
-  # grpc-connection-count: 16
+  # grpc-connection-count: 4
 
   # After a duration of this time in seconds if the client doesn't see any activity it pings
   # the server to see if the transport is still alive.

--- a/roles/tidb/vars/default.yml
+++ b/roles/tidb/vars/default.yml
@@ -135,7 +135,7 @@ opentracing:
 
 tikv_client:
   # Max gRPC connections that will be established with each tikv-server.
-  grpc-connection-count: 16
+  grpc-connection-count: 4
 
   # After a duration of this time in seconds if the client doesn't see any activity it pings
   # the server to see if the transport is still alive.


### PR DESCRIPTION
Signed-off-by: zhangjinpeng1987 <zhangjinpeng@pingcap.com>
TiDB https://github.com/pingcap/tidb/pull/12884 has change default value for grpc connection count, keep consistent with TiDB.