### PR TITLE
add alert rule for tidb binlog error count

### DIFF
--- a/roles/prometheus/files/tidb.rules.yml
+++ b/roles/prometheus/files/tidb.rules.yml
@@ -25,6 +25,18 @@ groups:
       value: '{{ $value }}'
       summary: TiDB tikvclient_backoff_count error
 
+  - alert: TiDB_binlog_error_total
+    expr: increase( tidb_server_binlog_error_total[1m] )  > 0
+    for: 1m
+    labels:
+      env: ENV_LABELS_ENV
+      level: emergency
+      expr:  increase( tidb_server_binlog_error_total[1m] )  > 0
+    annotations:
+      description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{ $value }}'
+      value: '{{ $value }}'
+      summary: TiDB tidb binlog error total
+
   - alert: TiDB_domain_load_schema_total
     expr: increase( tidb_domain_load_schema_total{type="failed"}[10m] )  > 10
     for: 1m

--- a/roles/prometheus/files/tidb.rules.yml
+++ b/roles/prometheus/files/tidb.rules.yml
@@ -26,12 +26,12 @@ groups:
       summary: TiDB tikvclient_backoff_count error
 
   - alert: TiDB_binlog_error_total
-    expr: increase( tidb_server_binlog_error_total[1m] )  > 0
+    expr: increase( tidb_server_critical_error_total[1m] )  > 0
     for: 1m
     labels:
       env: ENV_LABELS_ENV
       level: emergency
-      expr:  increase( tidb_server_binlog_error_total[1m] )  > 0
+      expr:  increase( tidb_server_critical_error_total[1m] )  > 0
     annotations:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{ $value }}'
       value: '{{ $value }}'

--- a/roles/prometheus/files/tidb.rules.yml
+++ b/roles/prometheus/files/tidb.rules.yml
@@ -26,12 +26,12 @@ groups:
       summary: TiDB tikvclient_backoff_count error
 
   - alert: TiDB_binlog_error_total
-    expr: increase( tidb_server_critical_error_total[1m] )  > 0
+    expr: increase( tidb_server_critical_error_total[5m] )  > 0
     for: 1m
     labels:
       env: ENV_LABELS_ENV
       level: emergency
-      expr:  increase( tidb_server_critical_error_total[1m] )  > 0
+      expr:  increase( tidb_server_critical_error_total[5m] )  > 0
     annotations:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{ $value }}'
       value: '{{ $value }}'

--- a/scripts/tidb.json
+++ b/scripts/tidb.json
@@ -3013,7 +3013,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Uncommon Error OPM",
+          "title": "Write Binlog Error",
           "tooltip": {
             "shared": true,
             "sort": 0,


### PR DESCRIPTION
Rename a TiDB metrics counter from `critical_error_total` to `binlog_error_total` and add alert rule for it.