### PR TITLE
remove kafka and zk in inventory

### DIFF
--- a/inventory.ini
+++ b/inventory.ini
@@ -78,14 +78,6 @@ set_hostname = False
 ## binlog trigger
 enable_binlog = False
 
-# kafka cluster address for monitoring, example:
-# kafka_addrs = "192.168.0.11:9092,192.168.0.12:9092,192.168.0.13:9092"
-kafka_addrs = ""
-
-# zookeeper address of kafka cluster for monitoring, example:
-# zookeeper_addrs = "192.168.0.11:2181,192.168.0.12:2181,192.168.0.13:2181"
-zookeeper_addrs = ""
-
 # enable TLS authentication in the TiDB cluster
 enable_tls = False
 


### PR DESCRIPTION
Since the current binlog do not depend on kafka and zk, so remove them from the `inventory.ini`