### PR TITLE
tidb-lightning: expose the "backend" setting; update Grafana dashboard

### DIFF
--- a/conf/tidb-lightning.yml
+++ b/conf/tidb-lightning.yml
@@ -17,7 +17,7 @@ lightning:
 
   # io-concurrency controls the maximum IO concurrency
   io-concurrency: 5
-  
+
   # logging
   level: "info"
   file: "log/tidb_lightning.log"
@@ -46,8 +46,12 @@ checkpoint:
   # keep-after-success: false
 
 tikv_importer:
-  # the listening address of tikv-importer. Change it to the actual address in tikv-importer.toml.
+  # delivery back end ("tidb" or "importer")
+  backend: "importer"
+  # the listening address of tikv-importer when back end is "importer". Change it to the actual address in tikv-importer.toml.
   # addr: "0.0.0.0:8287"
+  # action on duplicated entry ("error", "ignore" or "replace")
+  # on-duplicate: "replace"
 
 mydumper:
   # block size of file reading
@@ -105,7 +109,7 @@ tidb:
   # status-port: 10080
   # Lightning uses some code of TiDB (used as a library) and the flag controls its log level.
   log-level: "error"
-  
+
   # Set tidb session variables to speed up checksum/analyze table.
   # See https://pingcap.com/docs/sql/statistics/#control-analyze-concurrency for the meaning of each setting
   build-stats-concurrency: 20

--- a/roles/tidb_lightning/vars/tidb-lightning.yml
+++ b/roles/tidb_lightning/vars/tidb-lightning.yml
@@ -46,8 +46,12 @@ checkpoint:
   # keep-after-success: false
 
 tikv_importer:
-  # the listening address of tikv-importer. Change it to the actual address in tikv-importer.toml.
+  # delivery back end ("tidb" or "importer")
+  backend: "importer"
+  # the listening address of tikv-importer when back end is "importer". Change it to the actual address in tikv-importer.toml.
   # addr: "0.0.0.0:8287"
+  # action on duplicated entry ("error", "ignore" or "replace")
+  # on-duplicate: "replace"
 
 mydumper:
   # block size of file reading

--- a/scripts/lightning.json
+++ b/scripts/lightning.json
@@ -761,7 +761,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 6,
+          "span": 5,
           "stack": false,
           "steppedLine": true,
           "targets": [
@@ -837,7 +837,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 6,
+          "span": 5,
           "stack": false,
           "steppedLine": true,
           "targets": [
@@ -899,6 +899,76 @@
               "show": true
             }
           ]
+        },
+        {
+          "columns": [
+            {
+              "text": "Current",
+              "value": "current"
+            }
+          ],
+          "datasource": "${DS_LIGHTNING}",
+          "fontSize": "100%",
+          "id": 21,
+          "links": [],
+          "pageSize": null,
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 2,
+          "styles": [
+            {
+              "alias": "TiKV",
+              "pattern": "Metric"
+            },
+            {
+              "alias": "",
+              "colorMode": "cell",
+              "colors": [
+                "#E0B400",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 2,
+              "link": false,
+              "mappingType": 2,
+              "pattern": "Current",
+              "rangeMaps": [
+                {
+                  "from": "0",
+                  "text": "Import",
+                  "to": "0"
+                },
+                {
+                  "from": "1",
+                  "text": "Normal",
+                  "to": "Infinity"
+                }
+              ],
+              "thresholds": [
+                "1",
+                "1"
+              ],
+              "type": "string",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "min(tikv_config_rocksdb{name=\"hard_pending_compaction_bytes_limit\"}) by (instance)",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Import/Normal mode",
+          "transform": "timeseries_aggregations",
+          "type": "table"
         }
       ],
       "repeat": null,
@@ -1216,10 +1286,10 @@
               "refId": "B"
             },
             {
-              "expr": "pd_cluster_status{type=\"storage_size\"} / 3",
+              "expr": "pd_cluster_status{type=\"storage_size\"} / ignoring(type) pd_config_status{type=\"max_replicas\"}",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "storage_size / 3",
+              "legendFormat": "storage_size / replicas",
               "refId": "C"
             }
           ],


### PR DESCRIPTION
1. In `tidb-lightning.toml`, include the new `[tikv-importer] backend` and `on-duplicate` settings.
2. In the Grafana dashboard,
    * Added a panel to indicate if the TiKV is in Import or Normal mode
    * Changed the storage size from always divide by 3 to the actual replicas setting.