### PR TITLE
fix supervise error

### DIFF
--- a/roles/supervise/templates/start_role.sh.j2
+++ b/roles/supervise/templates/start_role.sh.j2
@@ -16,24 +16,12 @@ if [ "$(id -u)" -eq 0 ]; then
     exit 1
 fi
 
-# try up
-bin/svc -u "${STATUS_DIR}" &>/dev/null || true
 # check by svstat
 _check=$(bin/svstat "${STATUS_DIR}" 2>/dev/null)
 if echo "${_check}" | grep 'up pid' &>/dev/null; then
     _pid=$(echo "${_check}" | cut -d' ' -f 4 | cut -d',' -f 1)
-    if [ -e "/proc/${_pid}/cwd" ] && [ "`echo $(readlink /proc/${_pid}/cwd) | sed -r "s/^(.*)\/status.*$/\1/"`" == "${DEPLOY_DIR}" ]; then
-        echo "ok: already started!"
-        exit 0
-    fi
-fi
-
-# check by pid
-if [ -e "${STATUS_DIR}/pid" ]; then
-    _pid=$(cat "${STATUS_DIR}/pid")
-    if [ -e "/proc/${_pid}/cwd" ] && [ "$(readlink /proc/${_pid}/cwd)" == "${DEPLOY_DIR}" ]; then
-	kill -9 ${_pid}
-    fi
+    echo "ok: already started!"
+    exit 0
 fi
 
 {% if deployment_method == 'docker' %}

--- a/roles/supervise/templates/stop_role.sh.j2
+++ b/roles/supervise/templates/stop_role.sh.j2
@@ -4,26 +4,26 @@ set -e
 DEPLOY_USER={{ deploy_user }}
 STATUS_DIR={{ role_status_dir }}
 DEPLOY_DIR={{ deploy_dir }}
+ROLE_NAME={{ this_role_name }}
 
 cd "${DEPLOY_DIR}" || exit 1
 
 # try down
 bin/svc -d "${STATUS_DIR}" &>/dev/null || true
 
-# check by supervise pid
-if [ ! -z $(readlink /proc/$(cat ${STATUS_DIR}/pid)/exe) ]; then
-    if [ "$(basename "$(readlink /proc/$(cat ${STATUS_DIR}/pid)/exe)")" == "supervise" ]; then
-        kill $(cat ${STATUS_DIR}/pid)
-    fi
-fi
-
 # check by svstat
 _check=$(bin/svstat "${STATUS_DIR}" 2>/dev/null)
 if echo "${_check}" | grep 'up pid' &>/dev/null; then
     _pid=$(echo "${_check}" | cut -d' ' -f 4 | cut -d',' -f 1)
-    if [ "$(readlink /proc/${_pid}/cwd)" == "${DEPLOY_DIR}" ]; then
+    if [ `ps aux |grep ${_pid} | grep ${ROLE_NAME} | wc -l` -eq 1 ]; then
         kill ${_pid}
     fi
+fi
+
+# stop supervise
+_superpid=`cat ${STATUS_DIR}/pid`
+if [ `ps aux | grep ${_superpid} | grep "supervise" | grep "${DEPLOY_DIR}" | wc -l` -eq 1 ];then
+    kill -9 ${_superpid}
 fi
 
 echo -n "sync ... "; sync; echo "done!"


### PR DESCRIPTION
When the service is already running, using `supervise` to start service again will generate a different `pid` than the current process, which will cause the `supervise` process not stop properly. This pr will fix the problem.