### PR TITLE
conf/tikv: remove storage.scheduler-notify-capacity

### DIFF
--- a/conf/tikv.yml
+++ b/conf/tikv.yml
@@ -101,9 +101,6 @@ server:
   # labels: {}
 
 storage:
-  ## Internal notify capacity of Scheduler's channel.
-  # scheduler-notify-capacity: 10240
-
   ## The number of slots in Scheduler latches, which controls write concurrency.
   ## In most cases you can use the default value. When importing data, you can set it to a larger
   ## value.

--- a/roles/tikv/vars/default.yml
+++ b/roles/tikv/vars/default.yml
@@ -101,9 +101,6 @@ server:
   labels: {}
 
 storage:
-  ## Internal notify capacity of Scheduler's channel.
-  # scheduler-notify-capacity: 10240
-
   ## The number of slots in Scheduler latches, which controls write concurrency.
   ## In most cases you can use the default value. When importing data, you can set it to a larger
   ## value.


### PR DESCRIPTION
Remove useless config. https://github.com/tikv/tikv/pull/5827

Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>