### PR TITLE
drainer: Remove deprecated config value

### DIFF
--- a/conf/drainer.toml
+++ b/conf/drainer.toml
@@ -32,7 +32,7 @@ disable-dispatch = false
 safe-mode = false
 
 # downstream storage, equal to --dest-db-type
-# valid values are "mysql", "file", "tidb", "flash", "kafka"
+# valid values are "mysql", "file", "tidb", "kafka"
 db-type = "mysql"
 
 # ignore syncing the txn with specified commit ts to downstream


### PR DESCRIPTION
The `flash` downstream option has long been deprecated.
After pingcap/tidb-binlog#812 it would be removed from binlog.