### PR TITLE
scripts/tidb: add panel for ddl add index progress

### DIFF
--- a/scripts/tidb.json
+++ b/scripts/tidb.json
@@ -8692,7 +8692,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "TiDB ddl add index percentage progress. The value is [0,100]",
+          "description": "TiDB DDL add index progress in percentage. The value is [0,100]",
           "fill": 1,
           "gridPos": {
             "h": 8,
@@ -8738,7 +8738,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "DDL Add Index Percentage Progress",
+          "title": "DDL add index progress in percentage",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/scripts/tidb.json
+++ b/scripts/tidb.json
@@ -8692,7 +8692,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "TiDB ddl add index progress. The value is [0,100]",
+          "description": "TiDB ddl add index percentage progress. The value is [0,100]",
           "fill": 1,
           "gridPos": {
             "h": 8,
@@ -8727,7 +8727,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "tidb_ddl_add_index_progress",
+              "expr": "tidb_ddl_add_index_percentage_progress",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{instance}}",
@@ -8738,7 +8738,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "DDL Add Index Progress",
+          "title": "DDL Add Index Percentage Progress",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/scripts/tidb.json
+++ b/scripts/tidb.json
@@ -8692,7 +8692,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "TiDB ddl add index progress",
+          "description": "TiDB ddl add index progress. The value is [0,100]",
           "fill": 1,
           "gridPos": {
             "h": 8,

--- a/scripts/tidb.json
+++ b/scripts/tidb.json
@@ -8685,6 +8685,95 @@
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "TiDB ddl add index progress",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 33
+          },
+          "id": 193,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {},
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "tidb_ddl_add_index_progress",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "DDL Add Index Progress",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
       "repeat": null,


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/26020263/71234116-baf24d00-2332-11ea-900a-db1cfeefe1a8.png)




The add index progress = (added row count) / (total row count).