### PR TITLE
add unistore support for tidb-ansible

### DIFF
--- a/conf/unistore.yml
+++ b/conf/unistore.yml
@@ -1,0 +1,71 @@
+---
+## The default configuration file for unistore in YAML format
+##  Human-readable big numbers:
+##   Time(based on ms): ms, s, m, h
+##    e.g.: 78_000 = "1.3m"
+##
+##  TODO
+##   File size(based on byte): KB, MB, GB, TB, PB
+##    e.g.: 1_048_576 = "1MB"
+
+server:
+  ## PD server address
+  # pd-addr = "127.0.0.1:2379"
+  ## Unistore server address
+  # store-addr = "127.0.0.1:9191"
+
+  ## Unistore server http service address
+  # status-addr = "127.0.0.1:9291"
+
+  ## Log levels: trace, debug, info, warning, error, critical.
+  ## Note that `debug` and `trace` are only available in development builds.
+  # log-level = "info"
+  
+  ## Region size in bytes, default 64MB
+  # region-size = 67108864
+  
+  ## Max CPU cores to use, set 0 to use all CPU cores in the machine.
+  # max-procs = 0
+  
+  ## Raft store enabled or not
+  # raft = true
+  
+  
+raftstore:
+  ## Raft worker threads
+  #raft-workers = 2
+  
+engine:
+  ## Path for db storage
+  #db-path = "/tmp/badger"
+  
+  ## Value threshold for value or offset
+  #value-threshold = 256
+  
+  ## Maximum size for each table in bytes, default 64MB
+  #max-table-size = 67108864
+  
+  ## Maximum tables to keep in memory
+  #num-mem-tables = 3
+  
+  ## Maximum number of Level 0 tables before compacting
+  #num-L0-tables = 4
+  
+  ## Maximum number of Level 0 tables before stalling
+  #num-L0-tables-stall = 8
+  
+  ## Value log file size in bytes, default 256MB
+  #vlog-file-size = 268435456
+  
+  ## Sync data to disk
+  #sync-write = true
+  
+  ## Number of compaction workers
+  #num-compactors = 1
+  
+coprocessor:
+  ## When the number of keys in region [a,e) meets the region_max_keys,
+  ## it will be split into twoseveral regions [a,b), [b,c), [c,d), [d,e).
+  ## And the number of keys in [a,b), [b,c), [c,d) will be region_split_keys.
+  #region-max-keys = 1440000
+  #region-split-keys = 960000

--- a/deploy.yml
+++ b/deploy.yml
@@ -50,7 +50,14 @@
   tags:
     - tikv
   roles:
-    - check_config_tikv
+    - { role: check_config_tikv, when: use_unistore|default(False)|bool == False }
+
+- name: Pre-check unistore configuration
+  hosts: unistore_servers[0]
+  tags:
+    - unistore
+  roles:
+    - { role: check_config_unistore, when: use_unistore|default(False)|bool == True }
 
 - name: Pre-check TiDB configuration
   hosts: tidb_servers[0]
@@ -129,7 +136,14 @@
   tags:
     - tikv
   roles:
-    - tikv
+    - {role: tikv, when: use_unistore|default(False)|bool == False }
+
+- name: deploying unistore cluster
+  hosts: unistore_servers
+  tags:
+    - unistore
+  roles:
+    - {role: unistore, when: use_unistore|default(True)|bool == True }
 
 - name: deploying pump cluster
   hosts: pump_servers

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -48,3 +48,6 @@ pump_cert_dir: "{{ deploy_dir }}/conf/ssl"
 
 # drainer
 drainer_port: 8249
+
+# use unistore, set to True to deploy unistore cluster
+use_unistore: False

--- a/group_vars/unistore_servers.yml
+++ b/group_vars/unistore_servers.yml
@@ -1,0 +1,9 @@
+---
+dummy:
+
+unistore_port: 20160
+unistore_status_port: 20180
+
+unistore_data_dir: "{{ deploy_dir }}/data"
+unistore_log_dir: "{{ deploy_dir }}/log"
+unistore_cert_dir: "{{ deploy_dir }}/conf/ssl"

--- a/inventory.ini
+++ b/inventory.ini
@@ -1,16 +1,16 @@
 ## TiDB Cluster Part
 [tidb_servers]
-192.168.0.2
+192.168.246.140
 
 [tikv_servers]
-192.168.0.3
-192.168.0.4
-192.168.0.5
+
+[unistore_servers]
+unistore1 ansible_host=192.168.246.140 deploy_dir=/home/rwork/deploy/unistore/u1 unistore_port=26101 unistore_status_port=36101 labels="host=u1"
+unistore2 ansible_host=192.168.246.140 deploy_dir=/home/rwork/deploy/unistore/u2 unistore_port=26102 unistore_status_port=36102 labels="host=u2"
+unistore3 ansible_host=192.168.246.140 deploy_dir=/home/rwork/deploy/unistore/u3 unistore_port=26103 unistore_status_port=36103 labels="host=u3"
 
 [pd_servers]
-192.168.0.6
-192.168.0.7
-192.168.0.8
+192.168.246.140
 
 [spark_master]
 
@@ -23,24 +23,16 @@
 ## Monitoring Part
 # prometheus and pushgateway servers
 [monitoring_servers]
-192.168.0.10
+192.168.246.140
 
 [grafana_servers]
-192.168.0.10
+192.168.246.140
 
 # node_exporter and blackbox_exporter servers
 [monitored_servers]
-192.168.0.2
-192.168.0.3
-192.168.0.4
-192.168.0.5
-192.168.0.6
-192.168.0.7
-192.168.0.8
-192.168.0.10
+192.168.246.140
 
 [alertmanager_servers]
-192.168.0.10
 
 [kafka_exporter_servers]
 
@@ -55,13 +47,13 @@
 
 ## Global variables
 [all:vars]
-deploy_dir = /home/tidb/deploy
+deploy_dir = /home/rwork/deploy
 
 ## Connection
 # ssh via normal user
-ansible_user = tidb
+ansible_user = rwork
 
-cluster_name = test-cluster
+cluster_name = test-unistore-cluster
 
 tidb_version = latest
 

--- a/roles/check_config_static/tasks/main.yml
+++ b/roles/check_config_static/tasks/main.yml
@@ -22,7 +22,15 @@
 
 - name: Ensure TiKV host exists
   fail: msg="One, or more tikv hosts should be specified."
-  when: groups['tikv_servers'] | length < 1
+  when: 
+    - use_unistore|default(False)|bool == False
+    - groups['tikv_servers'] | length < 1
+
+- name: Ensure unistore host exists
+  fail: msg="One, or more unistore hosts should be specified."
+  when: 
+    - use_unistore|default(False)|bool == True
+    - groups['unistore_servers'] | length < 1
 
 - name: Check ansible_user variable
   fail: msg="ansible_user == 'root' is not supported, please ssh via normal user"

--- a/roles/check_config_unistore/tasks/main.yml
+++ b/roles/check_config_unistore/tasks/main.yml
@@ -1,0 +1,61 @@
+---
+
+- set_fact:
+    tidb_check_dir: "/tmp/tidb_check_config"
+
+- name: Create temporary check directory
+  file: name={{ tidb_check_dir }} state=directory
+
+- set_fact:
+    unistore_log_dir: "{{ deploy_dir }}/log"
+
+- name: Load unistore vars
+  include_vars: file={{ playbook_dir }}/roles/unistore/defaults/main.yml name=unistore_vars_check
+
+- name: "Load customized config: tidb-ansible/conf/unistore.yml"
+  include_vars: file={{ playbook_dir }}/conf/unistore.yml name=unistore_conf_custom_check
+
+- name: Load default config
+  include_vars: file={{ playbook_dir }}/roles/unistore/vars/default.yml name=unistore_conf_default_check
+
+- name: generate dynamic config
+  set_fact:
+    unistore_conf_generated_check:
+      server:
+        labels: "{{ unistore_vars_check.labels }}"
+      rocksdb:
+        wal-dir: "{{ unistore_vars_check.wal_dir }}"
+      raftstore:
+        raftdb-path: "{{ unistore_vars_check.raftdb_path }}"
+      security:
+        ca-path: >-
+          {%- if enable_tls|default(false) -%}{{ unistore_cert_dir }}/ca.pem{%- else -%}{%- endif -%}
+        cert-path: >-
+          {%- if enable_tls|default(false) -%}{{ unistore_cert_dir }}/unistore-server-{{ unistore_host }}.pem{%- else -%}{%- endif -%}
+        key-path: >-
+          {%- if enable_tls|default(false) -%}{{ unistore_cert_dir }}/unistore-server-{{ unistore_host }}-key.pem{%- else -%}{%- endif -%}
+
+- name: Generate final config
+  set_fact:
+    unistore_conf: "{{ unistore_conf_custom_check | with_default_dicts(unistore_conf_generated_check, unistore_conf_default_check) | update_default_dicts }}"
+
+- name: Create configuration file
+  template: src={{ playbook_dir }}/roles/unistore/templates/unistore.toml.j2 dest={{ tidb_check_dir }}/unistore.toml mode=0644 backup=yes
+
+- name: Deploy unistore binary
+  copy: src="{{ resources_dir }}/bin/unistore-server" dest="{{ tidb_check_dir }}/" mode=0755 backup=yes
+
+# TODO check config
+#- name: Check unistore config
+#  shell: cd {{ tidb_check_dir }} && ./unistore-server --config ./unistore.toml
+#  #shell: cd {{ tidb_check_dir }} && ./tikv-server --pd-endpoints pd:port --config ./tikv.toml --config-check
+#  register: unistore_check_result
+
+- name: Delete temporary check directory
+  file: name={{ tidb_check_dir }} state=absent
+
+# TODO
+#- name: Check result
+#  fail:
+#    msg: "unistore config error"
+#  when: "'successful' not in unistore_check_result.stdout"

--- a/roles/common_dir/tasks/main.yml
+++ b/roles/common_dir/tasks/main.yml
@@ -12,7 +12,7 @@
   file: path={{ item }} state=directory mode=0755
   with_items:
     - "{{ status_dir }}"
-  when: deployment_method == 'supervise' or 'tikv_servers' in group_names
+  when: deployment_method == 'supervise' or 'tikv_servers' in group_names or 'unistore_servers' in group_names
 
 - name: create deploy binary directory
   file: path={{ item }} state=directory mode=0755

--- a/roles/systemd/tasks/main.yml
+++ b/roles/systemd/tasks/main.yml
@@ -1,8 +1,11 @@
 ---
 # systemd configuration generation
 
+- debug: var=deployment_method
+
 - name: create systemd service configuration
   become: true
+  #template: src="systemd_{{ deployment_method }}.service.j2" dest="/home/rwork/deploy/{{ service_name }}.service" mode=0644
   template: src="systemd_{{ deployment_method }}.service.j2" dest="/etc/systemd/system/{{ service_name }}.service" mode=0644
 
 - name: create startup script - common start/stop

--- a/roles/unistore/defaults/main.yml
+++ b/roles/unistore/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+
+unistore_port: 20160
+unistore_status_port: 20180
+
+unistore_data_dir: "{{ deploy_dir }}/data"
+
+unistore_log_dir: "{{ deploy_dir }}/log"
+unistore_log_filename: "unistore.log"
+unistore_stderr_filename: "unistore_stderr.log"
+
+unistore_conf_dir: "{{ deploy_dir }}/conf"
+
+labels: {}
+
+wal_dir: ""
+
+raftdb_path: ""
+
+# docker settings
+unistore_docker_log_dir: "{{ unistore_log_dir }}/unistore"

--- a/roles/unistore/files/make-ssl.sh
+++ b/roles/unistore/files/make-ssl.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# Author: Smana smainklh@gmail.com
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o pipefail
+
+usage()
+{
+    cat << EOF
+Create self signed certificates
+
+Usage : $(basename $0) [-d <ssldir>]
+      -h | --help         : Show this message
+      -d | --ssldir       : Directory where the certificates will be located
+
+      Environmental variables HOSTS and CN should be set to generate keys
+      for each host.
+EOF
+}
+
+# Options parsing
+while (($#)); do
+    case "$1" in
+        -h | --help)   usage;   exit 0;;
+        -d | --ssldir) SSLDIR="${2}"; shift 2;;
+        *)
+            usage
+            echo "ERROR : Unknown option"
+            exit 3
+        ;;
+    esac
+done
+
+if [ -z ${SSLDIR} ]; then
+    echo "ERROR: the directory where the certificates will be located is missing. option -d"
+    exit 1
+fi
+
+tmpdir=$(mktemp -d /tmp/tidb_cacert.XXXXXX)
+trap 'rm -rf "${tmpdir}"' EXIT
+cd "${tmpdir}"
+
+mkdir -p "${SSLDIR}"
+
+if [ -e "$SSLDIR/ca-config.json" ]; then
+    # Reuse existing CA
+    cp $SSLDIR/{ca-config.json,ca-csr.json} .
+else
+    echo "ERROR: ca-config.json and ca-csr.json is missing in $SSLDIR."
+    exit 1
+fi
+
+# Root CA
+if [ -e "$SSLDIR/ca-key.pem" ]; then
+    # Reuse existing CA
+    cp $SSLDIR/{ca.pem,ca-key.pem} .
+else
+    cfssl gencert -initca ca-csr.json | cfssljson -bare ca - > /dev/null 2>&1
+fi
+
+# client cert
+if [ ! -e "$SSLDIR/client-key.pem" ]; then
+    echo '{"CN":"client","hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -profile=client -hostname="" - | cfssljson -bare client > /dev/null 2>&1
+fi
+
+gen_key_and_cert() {
+    local host=$1
+    local cn=$2
+    local name=$3
+    echo "{\"CN\":\"${cn}\",\"hosts\":[\"\"],\"key\":{\"algo\":\"rsa\",\"size\":2048}}" | cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -profile=server -hostname="${host},127.0.0.1" - | cfssljson -bare ${name} > /dev/null 2>&1
+}
+
+# Nodes
+if [ -n "$HOSTS" ]; then
+    for host in $HOSTS; do
+        gen_key_and_cert "${host}" "${CN}" "${CN}-${host}"
+    done
+fi
+
+# Install certs
+mv *.pem ${SSLDIR}/

--- a/roles/unistore/meta/main.yml
+++ b/roles/unistore/meta/main.yml
@@ -1,0 +1,4 @@
+---
+
+dependencies:
+  - role: common_dir

--- a/roles/unistore/tasks/binary_deployment.yml
+++ b/roles/unistore/tasks/binary_deployment.yml
@@ -1,0 +1,27 @@
+---
+
+- name: deploy binary
+  copy: src="{{ resources_dir }}/bin/unistore-server" dest="{{ deploy_dir }}/bin/" mode=0755 backup=yes
+  register: unistore_binary
+
+- name: backup binary file
+  command: mv "{{ unistore_binary.backup_file }}" "{{ backup_dir }}"
+  when: unistore_binary.changed and unistore_binary.backup_file is defined
+
+- name: create run script
+  template:
+    src: "{{ item }}_{{ role_name }}_binary.sh.j2"
+    dest: "{{ deploy_dir }}/scripts/{{ item }}_{{ role_name }}.sh"
+    mode: "0755"
+    backup: yes
+  with_items:
+    - run
+  vars:
+    role_status_dir: status/{{ role_name }}
+  register: unistore_script
+
+- name: backup script file
+  command: mv "{{ unistore_script.backup_file }}" "{{ backup_dir }}"
+  when: unistore_script.changed and unistore_script.backup_file is defined
+
+- include_tasks: "{{ process_supervision }}_deployment.yml"

--- a/roles/unistore/tasks/check_certs.yml
+++ b/roles/unistore/tasks/check_certs.yml
@@ -1,0 +1,91 @@
+---
+
+- name: "Check_certs | check if the certs have already been generated on control machine"
+  find:
+    paths: "{{ cert_dir }}"
+    patterns: "*.pem"
+    get_checksum: true
+  delegate_to: localhost
+  register: cert_control_node
+  run_once: true
+
+- debug:
+    var: cert_control_node
+
+- name: "Check_certs | Set default value for 'sync_certs', 'gen_certs' to false"
+  set_fact:
+    sync_certs: false
+    gen_certs: false
+
+- set_fact:
+    unistore_host: "{{ hostvars[inventory_hostname].ansible_host | default(inventory_hostname) }}"
+
+- name: "Check certs | check if a cert already exists on node"
+  stat:
+    path: "{{ unistore_cert_dir }}/{{ item }}"
+  register: cert_unistore_node
+  with_items:
+    - ca.pem
+    - unistore-server-{{ unistore_host }}-key.pem
+    - unistore-server-{{ unistore_host }}.pem
+
+- debug:
+    var: cert_unistore_node
+
+- name: "Check_certs | Set 'gen_certs' to true"
+  set_fact:
+    gen_certs: true
+  when: not item in cert_control_node.files|map(attribute='path') | list
+  delegate_to: localhost
+  run_once: true
+  with_items: >-
+       ['{{cert_dir}}/ca.pem',
+       {% set all_unistore_hosts = groups['unistore_servers']|unique|sort %}
+       {% for host in all_unistore_hosts %}
+         {% set unistore_ip = hostvars[host].ansible_host | default(hostvars[host].inventory_hostname) -%}
+         '{{cert_dir}}/unistore-server-{{ unistore_ip }}-key.pem'
+       {% if not loop.last %}{{','}}{% endif %}
+       {% endfor %}]
+
+- debug:
+    var: gen_certs
+
+- name: "Check_certs | Set 'gen_node_certs' to true"
+  set_fact:
+    gen_node_certs: |-
+      {
+      {% set all_unistore_hosts = groups['unistore_servers']|unique|sort -%}
+      {% set existing_certs = cert_control_node.files|map(attribute='path')|list|sort %}
+      {% for host in all_unistore_hosts -%}
+        {% set unistore_ip = hostvars[host].ansible_host | default(hostvars[host].inventory_hostname) -%}
+        {% set host_cert = "%s/unistore-server-%s-key.pem"|format(cert_dir, unistore_ip) %}
+        {% if host_cert in existing_certs -%}
+        "{{ host }}": False,
+        {% else -%}
+        "{{ host }}": True,
+        {% endif -%}
+      {% endfor %}
+      }
+  run_once: true
+
+- debug:
+    var: gen_node_certs
+
+- name: "Check_certs | Set unistore_cert_key"
+  set_fact:
+    unistore_cert_key_path:
+      "{{ cert_dir }}/unistore-server-{{ hostvars[inventory_hostname].unistore_host }}-key.pem"
+
+- debug:
+    var: unistore_cert_key_path
+
+- name: "Check_certs | Set 'sync_certs' to true"
+  set_fact:
+    sync_certs: true
+  when: gen_node_certs[inventory_hostname] or
+        (not cert_unistore_node.results[0].stat.exists|default(False)) or
+          (not cert_unistore_node.results[1].stat.exists|default(False)) or
+            (cert_unistore_node.results[1].stat.checksum|default('') != cert_control_node.files|selectattr("path","equalto",unistore_cert_key_path)|map(attribute="checksum")|first|default(''))
+
+- debug:
+    var: sync_certs

--- a/roles/unistore/tasks/check_filesystem.yml
+++ b/roles/unistore/tasks/check_filesystem.yml
@@ -1,0 +1,61 @@
+---
+
+- name: Get ansible_mounts fact
+  setup:
+    gather_subset: hardware
+    filter: ansible_mounts
+
+- name: Determine which mountpoint that unistore data dir exists on
+  shell: "df {{ unistore_data_dir }} | tail -n1 | awk '{print $NF}'"
+  register: deploy_partition
+  changed_when: False
+
+- set_fact:
+    xfs_filesystem: "true"
+  when:
+    - item.mount == deploy_partition.stdout
+    - item.fstype == 'xfs'
+  with_items: "{{ ansible_mounts }}"
+
+- name: Preflight check - Check bug if filesystem is xfs
+  shell: cd {{ unistore_data_dir }} && fallocate -n -o 0 -l 9192 tidb_test && printf 'a%.0s' {1..5000} > tidb_test && truncate -s 5000 tidb_test && fallocate -p -n -o 5000 -l 4192 tidb_test && LANG=en_US.UTF-8  stat tidb_test |awk 'NR==2{print $2}'
+  register: xfs_result
+  when:
+    - xfs_filesystem is defined
+    - xfs_filesystem
+
+- name: Clean check file for xfs filesystem
+  file: path={{ unistore_data_dir }}/tidb_test state=absent
+  when:
+    - xfs_filesystem is defined
+    - xfs_filesystem
+
+# TODO
+#- set_fact:
+#    ext4_filesystem_alert: "true"
+#  when:
+#    - item.mount == deploy_partition.stdout
+#    - item.fstype == 'ext4'
+#    - item.options.find("nodelalloc") == -1
+#  with_items: "{{ ansible_mounts }}"
+
+- name: Preflight check - Does unistore data dir meet ext4 file system requirement
+  fail:
+    msg: "You don't mount the file system of {{ deploy_partition.stdout }} with ext4 nodelalloc option. See https://github.com/pingcap/docs/blob/master/dev/how-to/deploy/orchestrated/ansible.md#step-8-mount-the-data-disk-ext4-filesystem-with-options-on-the-target-machines."
+  when:
+    - ext4_filesystem_alert is defined
+    - ext4_filesystem_alert
+
+- name: Preflight check - Set fssystem_check_result fact
+  set_fact:
+    fssystem_check_result: true
+  when: "(item.mount == deploy_partition.stdout and item.fstype == 'ext4') or (xfs_filesystem is defined and xfs_filesystem and xfs_result.stdout|int == 5000)"
+  with_items: "{{ ansible_mounts }}"
+
+- name: Preflight check - Does unistore data dir meet ext4 or xfs file system requirement
+  fail:
+    msg: 'The file system mounted at {{ item.mount }} does not meet ext4 or xfs file system requirement'
+  when:
+    - item.mount == deploy_partition.stdout
+    - fssystem_check_result is not defined
+  with_items: "{{ ansible_mounts }}"

--- a/roles/unistore/tasks/docker_deployment.yml
+++ b/roles/unistore/tasks/docker_deployment.yml
@@ -1,0 +1,28 @@
+---
+
+- name: create log directory
+  file: path="{{ item }}" state=directory mode=0755
+  with_items:
+  - "{{ unistore_docker_log_dir }}"
+
+- name: deploy unistore image
+  copy: src="{{ downloads_dir }}/unistore.tar" dest="{{ deploy_dir }}/images" mode=0755
+
+- name: create run script
+  template:
+    src: "{{ item }}_{{ role_name }}_docker.sh.j2"
+    dest: "{{ deploy_dir }}/scripts/{{ item }}_{{ role_name }}.sh"
+    mode: "0755"
+    backup: yes
+  with_items:
+    - run
+
+- name: load docker image from archive
+  docker_image:
+    state: present
+    force: yes
+    name: pingcap/unistore
+    tag: "{{ tidb_version }}"
+    load_path: "{{ images_dir }}/unistore.tar"
+
+- include_tasks: "{{ process_supervision }}_deployment.yml"

--- a/roles/unistore/tasks/gen_certs.yml
+++ b/roles/unistore/tasks/gen_certs.yml
@@ -1,0 +1,24 @@
+---
+
+- name: Gen_certs | copy certs generation script
+  copy:
+    src: "make-ssl.sh"
+    dest: "{{ script_dir }}/make-ssl.sh"
+    mode: 0700
+  run_once: yes
+  delegate_to: localhost
+  when: gen_certs|default(false)
+
+- name: Gen_certs | run cert generation script
+  command: "{{ script_dir }}/make-ssl.sh -d {{ cert_dir }}"
+  environment:
+    - HOSTS: "{% for h in groups['unistore_servers'] %}
+                {% if gen_node_certs[h]|default(true) %}
+                    {{ hostvars[h].ansible_host | default(hostvars[h].inventory_hostname) }}
+                {% endif %}
+              {% endfor %}"
+    - PATH: "{{ ansible_env.PATH }}:{{ binary_dir }}"
+    - CN: "unistore-server"
+  run_once: yes
+  delegate_to: localhost
+  when: gen_certs|default(false)

--- a/roles/unistore/tasks/install_certs.yml
+++ b/roles/unistore/tasks/install_certs.yml
@@ -1,0 +1,19 @@
+---
+
+- name: "Deploy_certs | Make sure the certificate directory exits"
+  file:
+    path: "{{ unistore_cert_dir }}"
+    state: directory
+    mode: 0700
+
+- name: "Deploy_certs | Deploy certificates"
+  copy:
+    src: "{{ cert_dir }}/{{ item }}"
+    dest: "{{ unistore_cert_dir }}/{{ item }}"
+    mode: 0600
+    backup: yes
+  with_items:
+    - ca.pem
+    - unistore-server-{{ unistore_host }}-key.pem
+    - unistore-server-{{ unistore_host }}.pem
+  when: sync_certs|default(false)

--- a/roles/unistore/tasks/main.yml
+++ b/roles/unistore/tasks/main.yml
@@ -1,0 +1,63 @@
+---
+# tasks file for unistore
+
+- name: create deploy directories
+  file: path={{ item }} state=directory mode=0755
+  with_items:
+  - "{{ unistore_log_dir }}"
+  - "{{ unistore_data_dir }}"
+  - "{{ unistore_conf_dir }}"
+
+- include_tasks: check_filesystem.yml
+
+- include_tasks: check_certs.yml
+  when: enable_tls|default(false)
+
+- include_tasks: gen_certs.yml
+  when: enable_tls|default(false)
+
+- include_tasks: install_certs.yml
+  when: enable_tls|default(false)
+
+- name: "load customized config: tidb-ansible/conf/unistore.yml"
+  include_vars: file={{ playbook_dir }}/conf/unistore.yml name=unistore_conf_custom
+
+- name: load default config
+  include_vars: file=default.yml name=unistore_conf_default
+
+- name: generate dynamic config
+  set_fact:
+    unistore_conf_generated:
+      server:
+        labels: "{{ labels }}"
+      rocksdb:
+        wal-dir: "{{ wal_dir }}"
+      raftstore:
+        raftdb-path: "{{ raftdb_path }}"
+      security:
+        ca-path: >-
+          {%- if enable_tls|default(false) -%}{{ unistore_cert_dir }}/ca.pem{%- else -%}{%- endif -%}
+        cert-path: >-
+          {%- if enable_tls|default(false) -%}{{ unistore_cert_dir }}/unistore-server-{{ unistore_host }}.pem{%- else -%}{%- endif -%}
+        key-path: >-
+          {%- if enable_tls|default(false) -%}{{ unistore_cert_dir }}/unistore-server-{{ unistore_host }}-key.pem{%- else -%}{%- endif -%}
+
+- name: generate final config
+  set_fact:
+    unistore_conf: "{{ unistore_conf_custom | with_default_dicts(unistore_conf_generated, unistore_conf_default) | update_default_dicts }}"
+
+- debug: var=unistore_conf
+
+- name: create config file
+  template: src=unistore.toml.j2 dest={{ deploy_dir }}/conf/unistore.toml mode=0644 backup=yes
+  register: unistore_conf_st
+
+- name: backup conf file
+  command: mv "{{ unistore_conf_st.backup_file }}" "{{ backup_dir }}"
+  when: unistore_conf_st.changed and unistore_conf_st.backup_file is defined
+
+- include_tasks: "{{ deployment_method }}_deployment.yml"
+
+- name: prepare firewalld white list
+  set_fact:
+    firewalld_ports: "{{ [unistore_port ~ '/tcp'] + firewalld_ports }}"

--- a/roles/unistore/tasks/supervise_deployment.yml
+++ b/roles/unistore/tasks/supervise_deployment.yml
@@ -1,0 +1,8 @@
+---
+
+- name: deploy supervise
+  include_role:
+    name: supervise
+  vars:
+    this_role_name: unistore
+    service_name: unistore-{{ unistore_port }}

--- a/roles/unistore/tasks/systemd_deployment.yml
+++ b/roles/unistore/tasks/systemd_deployment.yml
@@ -1,0 +1,8 @@
+---
+
+- name: deploy systemd
+  include_role:
+    name: systemd
+  vars:
+    this_role_name: unistore
+    service_name: unistore-{{ unistore_port }}

--- a/roles/unistore/templates/run_unistore_binary.sh.j2
+++ b/roles/unistore/templates/run_unistore_binary.sh.j2
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+ulimit -n 1000000
+
+# WARNING: This file was auto-generated. Do not edit!
+#          All your edit might be overwritten!
+cd "{{ deploy_dir }}" || exit 1
+
+{% set my_ip = hostvars[inventory_hostname].ansible_host | default(hostvars[inventory_hostname].inventory_hostname) -%}
+
+{% set my_peer_id = groups.unistore_servers.index(inventory_hostname) + 1 -%}
+
+{% set all_pd = [] -%}
+{% set pd_hosts = groups.pd_servers %}
+{% for host in pd_hosts -%}
+  {% set pd_ip = hostvars[host].ansible_host | default(hostvars[host].inventory_hostname) -%}
+  {% set pd_port = hostvars[host].pd_client_port -%}
+  {% set _ = all_pd.append("%s:%s" % (pd_ip, pd_port)) -%}
+{% endfor -%}
+
+export RUST_BACKTRACE=1
+
+export TZ=${TZ:-/etc/localtime}
+
+echo -n 'sync ... '
+stat=$(time sync)
+echo ok
+echo $stat
+
+echo $$ > "status/{{ role_name }}.pid"
+
+exec bin/unistore-server \
+    --data-dir "{{ unistore_data_dir }}" \
+    --addr "0.0.0.0:{{ unistore_port }}" \
+    --pd "{{ all_pd | join(',') }}" \
+    --config conf/unistore.toml \
+    --advertise-addr "{{ my_ip }}:{{ unistore_port }}" \
+    --status-addr "{{ my_ip }}:{{ unistore_status_port }}" \
+    --log-file "{{ unistore_log_dir }}/{{ unistore_log_filename }}" 2>> "{{ unistore_log_dir }}/{{ unistore_stderr_filename }}"

--- a/roles/unistore/templates/run_unistore_docker.sh.j2
+++ b/roles/unistore/templates/run_unistore_docker.sh.j2
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -e
+ulimit -n 1000000
+
+# WARNING: This file was auto-generated. Do not edit!
+#          All your edit might be overwritten!
+cd "{{ deploy_dir }}" || exit 1
+
+{% set my_ip = hostvars[inventory_hostname].ansible_host | default(hostvars[inventory_hostname].inventory_hostname) -%}
+
+{% set all_pd = [] -%}
+{% set pd_hosts = groups.pd_servers %}
+{% for host in pd_hosts -%}
+  {% set pd_ip = hostvars[host].ansible_host | default(hostvars[host].inventory_hostname) -%}
+  {% set pd_port = hostvars[host].pd_client_port -%}
+  {% set _ = all_pd.append("%s:%s" % (pd_ip, pd_port)) -%}
+{% endfor -%}
+
+export RUST_BACKTRACE=1
+
+export TZ=${TZ:-/etc/localtime}
+
+echo -n 'sync ... '
+stat=$(time sync)
+echo ok
+echo $stat
+
+echo $$ > "status/{{ role_name }}.pid"
+
+# TODO
+#  --advertise-addr="{{ my_ip }}:{{ unistore_port }}" \
+#  --status-addr "{{ my_ip }}:{{ unistore_status_port }}" \
+#  --data-dir=/data \
+#  --log-file="/var/log/{{ unistore_log_filename }}" \
+#  -p {{ unistore_port }}:20160 \
+#  -v /etc/localtime:/etc/localtime:ro \
+#  -v "{{ unistore_conf_dir }}/unistore.toml:/etc/unistore.toml:ro" \
+#  -v "{{ unistore_data_dir }}:/data" \
+#  -v "{{ unistore_docker_log_dir }}:/var/log" \
+#  -u `id -u {{ deploy_user }}` \
+#  --ulimit nofile=1000000:1000000 \
+#  --hostname "unistore-{{ unistore_port }}" \
+#  --name "unistore-{{ unistore_port }}" \
+#  pingcap/unistore:{{ tidb_version }} \
+exec docker run \
+  --addr="0.0.0.0:20160" \
+  --pd={{ all_pd | join(',') }} \
+  --config=/etc/unistore.toml

--- a/roles/unistore/templates/unistore.toml.j2
+++ b/roles/unistore/templates/unistore.toml.j2
@@ -1,0 +1,27 @@
+# unistore config template
+#  Human-readable big numbers:
+#   Time(based on ms): ms, s, m, h
+#    e.g.: 78_000 = "1.3m"
+#  TODO:
+#   File size(based on byte): KB, MB, GB, TB, PB
+#    e.g.: 1_048_576 = "1MB"
+
+[server]
+{% for item, value in unistore_conf.server | dictsort -%}
+{{ item }} = {{ value | to_json }}
+{% endfor %}
+
+[raftstore]
+{% for item, value in unistore_conf.raftstore | dictsort -%}
+{{ item }} = {{ value | to_json }}
+{% endfor %}
+
+[engine]
+{% for item, value in unistore_conf.engine | dictsort -%}
+{{ item }} = {{ value | to_json }}
+{% endfor %}
+
+[coprocessor]
+{% for item, value in unistore_conf.coprocessor | dictsort -%}
+{{ item }} = {{ value | to_json }}
+{% endfor %}

--- a/roles/unistore/vars/default.yml
+++ b/roles/unistore/vars/default.yml
@@ -1,0 +1,71 @@
+---
+## The default configuration file for unistore in YAML format
+##  Human-readable big numbers:
+##   Time(based on ms): ms, s, m, h
+##    e.g.: 78_000 = "1.3m"
+##
+##  TODO
+##   File size(based on byte): KB, MB, GB, TB, PB
+##    e.g.: 1_048_576 = "1MB"
+
+server:
+  ## PD server address
+  # pd-addr = "127.0.0.1:2379"
+  ## Unistore server address
+  # store-addr = "127.0.0.1:9191"
+
+  ## Unistore server http service address
+  # status-addr = "127.0.0.1:9291"
+
+  ## Log levels: trace, debug, info, warning, error, critical.
+  ## Note that `debug` and `trace` are only available in development builds.
+  # log-level = "info"
+  
+  ## Region size in bytes, default 64MB
+  # region-size = 67108864
+  
+  ## Max CPU cores to use, set 0 to use all CPU cores in the machine.
+  # max-procs = 0
+  
+  ## Raft store enabled or not
+  # raft = true
+  
+  
+raftstore:
+  ## Raft worker threads
+  #raft-workers = 2
+  
+engine:
+  ## Path for db storage
+  #db-path = "/tmp/badger"
+  
+  ## Value threshold for value or offset
+  #value-threshold = 256
+  
+  ## Maximum size for each table in bytes, default 64MB
+  #max-table-size = 67108864
+  
+  ## Maximum tables to keep in memory
+  #num-mem-tables = 3
+  
+  ## Maximum number of Level 0 tables before compacting
+  #num-L0-tables = 4
+  
+  ## Maximum number of Level 0 tables before stalling
+  #num-L0-tables-stall = 8
+  
+  ## Value log file size in bytes, default 256MB
+  #vlog-file-size = 268435456
+  
+  ## Sync data to disk
+  #sync-write = true
+  
+  ## Number of compaction workers
+  #num-compactors = 1
+  
+coprocessor:
+  ## When the number of keys in region [a,e) meets the region_max_keys,
+  ## it will be split into twoseveral regions [a,b), [b,c), [c,d), [d,e).
+  ## And the number of keys in [a,b), [b,c), [c,d) will be region_split_keys.
+  #region-max-keys = 1440000
+  #region-split-keys = 960000

--- a/start.yml
+++ b/start.yml
@@ -317,6 +317,78 @@
       debug:
         msg: "tikv binary or docker pid: {{ new_tikv_pid.stdout }}"
 
+#when: use_unistore|default(False)|bool == True
+- hosts: unistore_servers
+  tags:
+    - unistore
+  tasks:
+    - name: Check if unistore_port already in use
+      wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ unistore_port }}"
+        state: stopped
+        timeout: 3
+        msg: "{{ unistore_port }} already in use"
+
+    - name: Check if unistore_status_port already in use
+      wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ unistore_status_port }}"
+        state: stopped
+        timeout: 3
+        msg: "{{ unistore_status_port }} already in use"
+
+    - name: start unistore by supervise
+      shell: cd {{ deploy_dir }}/scripts && ./start_{{ item }}.sh
+      when: process_supervision == 'supervise'
+      with_items:
+        - unistore
+
+    - name: start unistore by systemd
+      systemd: name=unistore-{{ unistore_port }}.service state=started enabled=no
+      become: true
+      when: process_supervision == 'systemd'
+
+    - name: wait until the unistore port is up
+      wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ unistore_port }}"
+        state: started
+        msg: "the unistore port {{ unistore_port }} is not up"
+
+    # TODO
+    #- name: wait until the unistore status page is available
+    #  uri:
+    #    url: "http://{{ ansible_host }}:{{ unistore_status_port }}/status"
+    #    return_content: yes
+    #  register: unistore_http_result
+    #  until: unistore_http_result.status == 200
+    #  retries: 12
+    #  delay: 5
+    #  when: not enable_tls|default(false)
+
+    #- name: wait until the unistore status page is available when enable_tls
+    #  uri:
+    #    url: "https://{{ ansible_host }}:{{ unistore_status_port }}/status"
+    #    validate_certs: no
+    #    client_cert: "{{ unistore_cert_dir }}/unistore-server-{{ ansible_host }}.pem"
+    #    client_key: "{{ unistore_cert_dir }}/unistore-server-{{ ansible_host }}-key.pem"
+    #    return_content: yes
+    #  register: unistore_https_result
+    #  until: unistore_https_result.status == 200
+    #  retries: 10
+    #  delay: 5
+    #  when: enable_tls|default(false)
+
+    - command: cat {{ deploy_dir }}/status/unistore.pid
+      register: new_unistore_pid
+      ignore_errors: yes
+      changed_when: false
+
+    - name: display new unistore pid
+      debug:
+        msg: "unistore binary or docker pid: {{ new_unistore_pid.stdout }}"
+
 - hosts: pd_servers[0]
   tasks:
     - name: wait for region replication complete

--- a/stop.yml
+++ b/stop.yml
@@ -260,6 +260,36 @@
       debug:
         msg: "tikv binary or docker pid: {{ old_tikv_pid.stdout }}"
 
+- hosts: unistore_servers
+  tags:
+    - unistore
+  tasks:
+    - name: stop unistore by supervise
+      shell: cd {{ deploy_dir }}/scripts && ./stop_{{ item }}.sh
+      when: process_supervision == 'supervise'
+      with_items:
+        - unistore
+
+    - name: stop unistore by systemd
+      systemd: name=unistore-{{ unistore_port }}.service state=stopped
+      become: true
+      when: process_supervision == 'systemd'
+
+    - name: wait until the unistore port is down
+      wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ unistore_port }}"
+        state: stopped
+        msg: "the unistore port {{ unistore_port }} is not down"
+
+    - command: cat {{ deploy_dir }}/status/unistore.pid
+      register: old_unistore_pid
+      ignore_errors: yes
+      changed_when: false
+
+    - name: display old unistore pid
+      debug:
+        msg: "unistore binary or docker pid: {{ old_unistore_pid.stdout }}"
 
 - hosts: pd_servers
   tags:

--- a/unsafe_cleanup.yml
+++ b/unsafe_cleanup.yml
@@ -100,6 +100,23 @@
       file: path={{ raftdb_path }} state=absent
       when: "raftdb_path is defined"
 
+- hosts: unistore_servers
+  tasks:
+    - name: clean systemd config
+      file: path="/etc/systemd/system/{{ item }}" state=absent
+      become: true
+      when: process_supervision == 'systemd'
+      with_items:
+        - unistore-{{ unistore_port }}.service
+
+    - name: cleaning up wal dir
+      file: path={{ wal_dir }} state=absent
+      when: "wal_dir is defined"
+
+    - name: cleaning up raftdb dir
+      file: path={{ raftdb_path }} state=absent
+      when: "raftdb_path is defined"
+
 - hosts: pd_servers
   tasks:
     - name: clean systemd config


### PR DESCRIPTION
Integrate `unistore` into `tidb.ansbile`, make it convenient to do complex tests and benchmark on IDC servers for unistore.

The following utilities have been tested on my local dev machine

An origin/unistore branch is needed, do not merge this into master

```
deploy
start
stop
unsafe_cleanup
```

TODO:
1. Other utilities like upgrade etc
2. Monitor metric related changes, to make `unistore` observable, like metrics and panels
