### PR TITLE
roles: remove pd namespace config

### DIFF
--- a/conf/pd.yml
+++ b/conf/pd.yml
@@ -5,8 +5,6 @@ global:
   # lease: 3
   # tso-save-interval: "3s"
 
-  # namespace-classifier: "table"
-
   # enable-prevote: true
 
 security:

--- a/conf/pd.yml
+++ b/conf/pd.yml
@@ -45,10 +45,10 @@ schedule:
   # max-pending-peer-count: 16
   # max-store-down-time: "30m"
   # leader-schedule-limit: 4
-  # region-schedule-limit: 4
-  # replica-schedule-limit: 8
+  # region-schedule-limit: 2048
+  # replica-schedule-limit: 64
   # merge-schedule-limit: 8
-  # tolerant-size-ratio: 5.0
+  # tolerant-size-ratio: 0.0
 
 replication:
   # The number of replicas for each region.

--- a/roles/pd/vars/default.yml
+++ b/roles/pd/vars/default.yml
@@ -58,10 +58,10 @@ schedule:
   max-pending-peer-count: 16
   max-store-down-time: "30m"
   leader-schedule-limit: 4
-  region-schedule-limit: 4
-  replica-schedule-limit: 8
+  region-schedule-limit: 2048
+  replica-schedule-limit: 64
   merge-schedule-limit: 8
-  tolerant-size-ratio: 5.0
+  tolerant-size-ratio: 0.0
 
 replication:
   # The number of replicas for each region.

--- a/roles/pd/vars/default.yml
+++ b/roles/pd/vars/default.yml
@@ -19,8 +19,6 @@ global:
   lease: 3
   tso-save-interval: "3s"
 
-  namespace-classifier: "table"
-
   enable-prevote: true
 
 security:


### PR DESCRIPTION
Based on #978, especially remove `namespace-classifier` for the compatibility problem. 