### PR TITLE
Add TLS support for dashboard_topo

### DIFF
--- a/roles/dashboard_topo/templates/init_dashboard_topo.sh.j2
+++ b/roles/dashboard_topo/templates/init_dashboard_topo.sh.j2
@@ -44,4 +44,8 @@ set -e
   {% set flag = flag + " --prometheus " + ','.join(all_prometheus) -%}
 {% endif -%}
 
+{% if enable_tls|default(false) %}
+  {% set flag = flag + " --cacert_file %s/ca.pem --cert_file %s/client.pem --key_file %s/client-key.pem" %(cert_dir, cert_dir, cert_dir) -%}
+{% endif %}
+
 python2 dashboard_topo.py --pd {{ all_pd | join(',') }} {{ flag }}

--- a/scripts/dashboard_topo.py
+++ b/scripts/dashboard_topo.py
@@ -3,13 +3,65 @@
 from __future__ import print_function, \
     unicode_literals
 
-import urllib
+import httplib
+import ssl
+import sys
 import urllib2
 import base64
 import json
 import argparse
+import socket
 
 ComponentToRegister = ('alertmanager', 'grafana', 'pd', 'prometheus')
+
+
+class HTTPSClientAuthConnection(httplib.HTTPSConnection):
+    def __init__(self, host, key_file=None, cert_file=None, ca_certs=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
+        httplib.HTTPSConnection.__init__(self, host, key_file=key_file, cert_file=cert_file, timeout=timeout)
+        self.ca_certs = ca_certs
+
+    def connect(self):
+        httplib.HTTPConnection.connect(self)
+        self.sock = ssl.wrap_socket(self.sock, self.key_file, self.cert_file, ca_certs=self.ca_certs)
+
+
+class HTTPSClientAuthHandler(urllib2.HTTPSHandler):
+    def __init__(self, key_file, cert_file, ca_certs):
+        urllib2.HTTPSHandler.__init__(self)
+        self.key_file = key_file
+        self.cert_file = cert_file
+        self.ca_certs = ca_certs
+
+    def https_open(self, url):
+        return self.do_open(HTTPSClientAuthConnection, url, key_file=self.key_file, cert_file=self.cert_file, ca_certs=self.ca_certs)
+
+
+def req_with_context(url, key_file, cert_file, ca_certs):
+    """
+    Python2 added context to HTTPSHandler
+    """
+    context = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH, cafile=ca_certs)
+    context.load_cert_chain(certfile=cert_file, keyfile=key_file)
+    opener = urllib2.build_opener(urllib2.HTTPSHandler(context=context))
+    return opener.open(url)
+
+
+def req_without_context(url, key_file, cert_file, ca_certs):
+    """
+    Used for python before 2.7.9
+    """
+    opener = urllib2.build_opener(HTTPSClientAuthHandler(ca_certs=ca_certs, key_file=key_file, cert_file=cert_file))
+    return opener.open(url)
+
+
+def http_request(url, key_file, cert_file, ca_certs):
+    if not key_file:
+        return urllib2.urlopen(url)
+    if sys.version_info.minor < 9:
+        req_func = req_without_context
+    else:
+        req_func = req_with_context
+    return req_func(url, key_file, cert_file, ca_certs)
 
 
 def parse_opts():
@@ -21,22 +73,27 @@ def parse_opts():
     for target in ComponentToRegister:
         parser.add_argument("--{}".format(target),
                             help="the address list of {}".format(target))
+    for ssl_arg in ("key_file", "cert_file", "cacert_file"):
+        parser.add_argument("--{}".format(ssl_arg),
+                            help="path of the ".format(ssl_arg))
+
     args, unknown = parser.parse_known_args()
     return args
 
 
-def etcd_write(etcd_url, key, value):
+def etcd_write(etcd_url, key, value, key_file, cert_file, cacert_file):
     encoded_key = base64.b64encode(key)
     encoded_value = base64.b64encode(value)
     data = json.dumps({
         "key": encoded_key,
         "value": encoded_value,
     })
-    req = urllib2.Request('http://' + etcd_url + '/v3/kv/put',
+    scheme = "https" if key_file else "http"
+    req = urllib2.Request(scheme + '://' + etcd_url + '/v3/kv/put',
                           data=data,
                           headers={'Content-Type': 'application/json'})
     try:
-        resp = urllib2.urlopen(req)
+        resp = http_request(req, key_file, cert_file, cacert_file)
         data = json.load(resp)
         return data
     except urllib2.HTTPError as error:
@@ -52,7 +109,7 @@ def parse_address(con):
     return (con[:pos], con[pos:])
 
 
-def request_topo(comp, topo, etcd_target):
+def request_topo(comp, topo, etcd_target, key_file, cert_file, cacert_file):
     """
     Sending request to etcd v3, and leave:
     under {pd_target}:
@@ -61,6 +118,9 @@ def request_topo(comp, topo, etcd_target):
     comp: str for component name, which will be like "tidb"
     topo: str for topology address, like "127.0.0.1:4000"
     pd_target: the place to send etcd request, like "127.0.0.1:2379"
+    key_file: TSL key file
+    cert_file: TSL cert file
+    cacert_file: TSL ca file
     """
     if topo is None:
         # if topo is None, do nothing
@@ -75,7 +135,7 @@ def request_topo(comp, topo, etcd_target):
         'binary_path': add,
         'port': int(port),
     })
-    etcd_write(etcd_target, "/topology/" + comp, message)
+    etcd_write(etcd_target, "/topology/" + comp, message, key_file, cert_file, cacert_file)
 
 
 def concat_to_address(ip, port):
@@ -93,6 +153,7 @@ def concat_to_address(ip, port):
 
 if __name__ == '__main__':
     args = parse_opts()
+    print(args)
 
     # parse from args
     pd_address = args.pd
@@ -111,4 +172,4 @@ if __name__ == '__main__':
     for comp in ComponentToRegister:
         if comp == 'pd':
             continue
-        request_topo(comp, mapping[comp], pd_address_zero)
+        request_topo(comp, mapping[comp], pd_address_zero, args.key_file, args.cert_file, args.cacert_file)


### PR DESCRIPTION
Signed-off-by: niedhui <niedhui@gmail.com>

This PR adds TLS support for dashboard_topo. Since we need support Python 2.7.5+,  there's tow client authentication implementation. One is for 2.7.9+ which add [SSLContext](https://docs.python.org/2/library/ssl.html#ssl.SSLContext) to [HTTPSHandler](https://docs.python.org/2/library/urllib2.html?highlight=httpshandler#urllib2.HTTPSHandler). One is for python2 version below 2.7.9, a little boring.

I had only tested the generated script, `dashboard_topo.sh`, sending requests to a manual deployed 
PD.

#### related PR
https://github.com/pingcap-incubator/tidb-dashboard/pull/195