### PR TITLE
update pd-ctl.sh.j2 for release-3.0 (#1213)

### DIFF
--- a/roles/ops/templates/pd-ctl.sh.j2
+++ b/roles/ops/templates/pd-ctl.sh.j2
@@ -2,5 +2,5 @@
 {% if enable_tls|default(false) %}
 {{ resources_dir }}/bin/pd-ctl -u https://{{ groups.pd_servers[0] }}:{{ hostvars[groups.pd_servers[0]].pd_client_port }} --cacert {{ cert_dir }}/ca.pem --cert {{ cert_dir }}/client.pem --key {{ cert_dir }}/client-key.pem
 {%- else -%}
-{{ resources_dir }}/bin/pd-ctl -u http://{{ groups.pd_servers[0] }}:{{ hostvars[groups.pd_servers[0]].pd_client_port }}
+{{ resources_dir }}/bin/pd-ctl -u http://{{ groups.pd_servers[0] }}:{{ hostvars[groups.pd_servers[0]].pd_client_port }} -i
 {% endif %}


### PR DESCRIPTION
In newer versions, the pd-ctl interactive mode parameter is changed to -i, corresponding to tidb-ansible also needs to be changed.