### PR TITLE
sync unified read pool default configurations with tikv#7234

### DIFF
--- a/conf/tikv.yml
+++ b/conf/tikv.yml
@@ -19,13 +19,7 @@ global:
   # log-rotation-timespan: "24h"
 
 readpool:
-  ## (Experimental) Whether to use a single thread pool to serve all the read requests. If it is
-  ## set to `true`, the `readpool.storage` and `readpool.coprocessor` sections will be invalid and
-  ## be ignored automatically.
-  # unify-read-pool: true
-
   ## Configurations for the single thread pool serving read requests.
-  ## It only takes effect when `unify-read-pool` is `true`.
   unified:
     ## The minimal working thread count of the thread pool.
     # min-thread-count: 1
@@ -41,6 +35,11 @@ readpool:
     # max-tasks-per-worker: 2000
 
   storage:
+    ## Whether to use the unified read pool to handle storage requests.
+    # use-unified-pool = false
+
+    ## The following configurations only take effect when `use-unified-pool` is false.
+
     ## Size of the thread pool for high-priority operations.
     # high-concurrency: 4
 
@@ -63,6 +62,11 @@ readpool:
     # stack-size: "10MB"
 
   coprocessor:
+    ## Whether to use the unified read pool to handle storage requests.
+    # use-unified-pool = true
+
+    ## The following configurations only take effect when `use-unified-pool` is false.
+
     ## Most read requests from TiDB are sent to the coprocessor of TiKV. high/normal/low-concurrency is
     ## used to set the number of threads of the coprocessor.
     ## If there are many read requests, you can increase these config values (but keep it within the

--- a/roles/tikv/vars/default.yml
+++ b/roles/tikv/vars/default.yml
@@ -19,13 +19,7 @@ global:
   # log-rotation-timespan: "24h"
 
 readpool:
-  ## (Experimental) Whether to use a single thread pool to serve all the read requests. If it is
-  ## set to `true`, the `readpool.storage` and `readpool.coprocessor` sections will be invalid and
-  ## be ignored automatically.
-  # unify-read-pool: true
-
   ## Configurations for the single thread pool serving read requests.
-  ## It only takes effect when `unify-read-pool` is `true`.
   unified:
     ## The minimal working thread count of the thread pool.
     # min-thread-count: 1


### PR DESCRIPTION
https://github.com/tikv/tikv/pull/7234 changes the default configuration of tikv, making it not use the unified pool to handle storage requests. Synchronize ansible with that change.

DNM until https://github.com/tikv/tikv/pull/7234 is merged.

Note that this PR should be cherry-picked to 4.0.