### PR TITLE
set madvdontneed=1 to shrink RSS after GC

### DIFF
--- a/roles/tidb/templates/run_tidb_binary.sh.j2
+++ b/roles/tidb/templates/run_tidb_binary.sh.j2
@@ -21,7 +21,7 @@ cd "${DEPLOY_DIR}" || exit 1
 
 export TZ={{ timezone }}
 
-exec bin/tidb-server \
+exec env GODEBUG=madvdontneed=1 bin/tidb-server \
     -P {{ tidb_port }} \
     --status="{{ tidb_status_port }}" \
     --advertise-address="{{ my_ip }}" \


### PR DESCRIPTION
Go 1.13 use `MADV_FREE` which will cause RSS don't shrink even if heap size is shrunk.

Set `madvdontneed=1` in `GODEBUG` will ask runtime use `MADV_DONTNEED`, which will shrink RSS size more quickly.