### PR TITLE
let tiflash tmp_path use DataDir instead of DeployDir (#1270)

### DIFF
--- a/roles/tiflash/defaults/main.yml
+++ b/roles/tiflash/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 
 tiflash_dir: "{{ deploy_dir }}/tiflash"
-tmp_path: "{{ deploy_dir }}/tiflash/data/tmp"
 data_dir: "{{ deploy_dir }}/tiflash/data/db"
+tmp_path: "{{ data_dir | split_string(',') | get_element_by_index(0) }}/tmp"
 cluster_manager_path: "{{ deploy_dir }}/bin/tiflash/flash_cluster_manager"
 cluster_manager_log: "{{ deploy_dir }}/log/tiflash_cluster_manager.log"
 tiflash_tikv_log: "{{ deploy_dir }}/log/tiflash_tikv.log"


### PR DESCRIPTION
cherry pick https://github.com/pingcap/tidb-ansible/pull/1270