### PR TITLE
pd: remove balance ratio from the overview dashboard

### DIFF
--- a/scripts/overview.json
+++ b/scripts/overview.json
@@ -57,8 +57,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "id": null,
-  "iteration": 1564756163207,
+  "id": 16,
+  "iteration": 1589955214147,
   "links": [],
   "panels": [
     {
@@ -776,14 +776,14 @@
         {
           "cacheTimeout": null,
           "colorBackground": false,
-          "colorValue": true,
+          "colorValue": false,
           "colors": [
             "#299c46",
             "rgba(237, 129, 40, 0.89)",
             "#d44a3a"
           ],
           "datasource": "${DS_TEST-CLUSTER}",
-          "format": "percentunit",
+          "format": "none",
           "gauge": {
             "maxValue": 100,
             "minValue": 0,
@@ -793,7 +793,7 @@
           },
           "gridPos": {
             "h": 7,
-            "w": 2,
+            "w": 4,
             "x": 16,
             "y": 2
           },
@@ -834,7 +834,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "1 - min(pd_scheduler_store_status{instance=\"$instance\", namespace=~\"$namespace\", type=\"leader_score\"}) / max(pd_scheduler_store_status{instance=\"$instance\", namespace=~\"$namespace\", type=\"leader_score\"})",
+              "expr": "sum(pd_cluster_status{instance=\"$instance\", type=\"store_up_count\"})",
               "format": "time_series",
               "interval": "15s",
               "intervalFactor": 2,
@@ -842,88 +842,7 @@
             }
           ],
           "thresholds": "0.01,0.5",
-          "title": "Leader Balance Ratio",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "current"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": true,
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
-          "datasource": "${DS_TEST-CLUSTER}",
-          "format": "percentunit",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 2,
-            "x": 18,
-            "y": 2
-          },
-          "id": 65,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": true,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": true
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "expr": "1 - min(pd_scheduler_store_status{instance=\"$instance\", namespace=~\"$namespace\", type=\"region_score\"}) / max(pd_scheduler_store_status{instance=\"$instance\", namespace=~\"$namespace\", type=\"region_score\"})",
-              "format": "time_series",
-              "interval": "15s",
-              "intervalFactor": 2,
-              "refId": "A"
-            }
-          ],
-          "thresholds": "0.05,0.5",
-          "title": "Region Balance Ratio",
+          "title": "Normal stores",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -1083,6 +1002,7 @@
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null as zero",
+          "paceLength": 10,
           "percentage": false,
           "pointradius": 5,
           "points": false,
@@ -1176,6 +1096,7 @@
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null as zero",
+          "paceLength": 10,
           "percentage": false,
           "pointradius": 5,
           "points": false,
@@ -1272,6 +1193,7 @@
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
+          "paceLength": 10,
           "percentage": false,
           "pointradius": 5,
           "points": false,
@@ -1369,6 +1291,7 @@
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
+          "paceLength": 10,
           "percentage": false,
           "pointradius": 5,
           "points": false,
@@ -1459,6 +1382,7 @@
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
+          "paceLength": 10,
           "percentage": false,
           "pointradius": 5,
           "points": false,
@@ -1548,6 +1472,7 @@
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null as zero",
+          "paceLength": 10,
           "percentage": false,
           "pointradius": 5,
           "points": false,
@@ -1639,6 +1564,7 @@
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null as zero",
+          "paceLength": 10,
           "percentage": false,
           "pointradius": 5,
           "points": false,
@@ -5236,7 +5162,10 @@
     "list": [
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "text": "r1-pd-0",
+          "value": "r1-pd-0"
+        },
         "datasource": "${DS_TEST-CLUSTER}",
         "definition": "",
         "hide": 0,
@@ -5258,7 +5187,10 @@
       },
       {
         "allValue": ".*",
-        "current": {},
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "${DS_TEST-CLUSTER}",
         "definition": "",
         "hide": 0,
@@ -5311,6 +5243,6 @@
   },
   "timezone": "browser",
   "title": "Test-Cluster-Overview",
-  "uid": "eDbRZpnWk",
-  "version": 11
+  "uid": "nbyPWugMz",
+  "version": 1
 }


### PR DESCRIPTION
Signed-off-by: Shafreeck Sea <shafreeck@gmail.com>

![image](https://user-images.githubusercontent.com/418483/82412190-cabeba80-9aa5-11ea-95cc-4d3d90005ecd.png)

The balance ratio has been abandoned from 3.0. Use `Normal stores` which keeps the same with the master branch.

![image](https://user-images.githubusercontent.com/418483/82412372-1e310880-9aa6-11ea-9b93-048a46ec2fa6.png)