### PR TITLE
Fix tikv config check failure on deploy (#1306)

### DIFF
--- a/conf/tikv.yml
+++ b/conf/tikv.yml
@@ -600,14 +600,14 @@ security:
     ##       type: "file"
     ##       path: "/path/to/master/key/file"
     ##
-    master-key:
-      # type = "plaintext"
+    # master-key:
+    #   type = "plaintext"
     
     ## Specifies the old master key when rotating master key. Same config format as master-key.
     ## The key is only access once during TiKV startup, after that TiKV do not need access to the key.
     ## And it is okay to leave the stale previous-master-key config after master key rotation.
-    previous-master-key:
-      # type: "plaintext"
+    # previous-master-key:
+    #   type: "plaintext"
 
 import:
 

--- a/roles/tikv/vars/default.yml
+++ b/roles/tikv/vars/default.yml
@@ -596,14 +596,14 @@ security:
     ##       type: "file"
     ##       path: "/path/to/master/key/file"
     ##
-    master-key:
-      # type = "plaintext"
+    # master-key:
+    #   type = "plaintext"
     
     ## Specifies the old master key when rotating master key. Same config format as master-key.
     ## The key is only access once during TiKV startup, after that TiKV do not need access to the key.
     ## And it is okay to leave the stale previous-master-key config after master key rotation.
-    previous-master-key:
-      # type: "plaintext"
+    # previous-master-key:
+    #   type: "plaintext"
 
 import:
 


### PR DESCRIPTION
Fix tikv config check failure on deploy due to wrong format of config template:
```
[TiKV1-1]: Ansible Failed! ==>
  changed=true
  cmd: cd /tmp/tidb_check_config && ./tikv-server --pd-endpoints pd:port --config ./tikv.toml --config-check
  delta: '0:00:00.524112'
  end: '2020-05-25 14:35:13.870777'
  msg: non-zero return code
  rc: 101
  start: '2020-05-25 14:35:13.346665'
  stderr: |-
    thread 'main' panicked at 'invalid auto generated configuration file ./tikv.toml, err missing field `type` for key `security.encryption.master-key`', /rustc/b2e36e6c2d229126b59e892c9147fbb68115d292/src/libstd/macros.rs:16:9
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
  stderr_lines:
  - thread 'main' panicked at 'invalid auto generated configuration file ./tikv.toml, err missing field `type` for key `security.encryption.master-key`', /rustc/b2e36e6c2d229126b59e892c9147fbb68115d292/src/libstd/macros.rs:16:9
  - 'note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace'
  stdout: ''
  stdout_lines: <omitted>
``` 

The is because the `type` field of `[security.encryption.master-key]` is required if the table header presents.

Signed-off-by: Yi Wu <yiwu@pingcap.com>