### PR TITLE
Do not hide disk write latency

### DIFF
--- a/scripts/disk_performance.json
+++ b/scripts/disk_performance.json
@@ -116,7 +116,6 @@
           "errors": {},
           "expr": "(rate(node_disk_write_time_seconds_total{device=~\"$device\", instance=\"$host\"}[$interval]) / rate(node_disk_writes_completed_total{device=~\"$device\", instance=\"$host\"}[$interval])) or (irate(node_disk_write_time_seconds_total{device=~\"$device\", instance=\"$host\"}[5m]) / irate(node_disk_writes_completed_total{device=~\"$device\", instance=\"$host\"}[5m]))",
           "format": "time_series",
-          "hide": true,
           "interval": "$interval",
           "intervalFactor": 1,
           "legendFormat": "Write: {{ device }}",


### PR DESCRIPTION
Write latency should not be hidden, especially when some clients doesn't have the permission to toggle it on.

Signed-off-by: Xinye Tao <xy.tao@outlook.com>